### PR TITLE
Follow rust naming convention in snippets

### DIFF
--- a/const.sublime-snippet
+++ b/const.sublime-snippet
@@ -1,5 +1,5 @@
 <snippet>
-    <content><![CDATA[const ${1:var}: ${2:typ} = ${4:val}]]></content>
+    <content><![CDATA[const ${1:VAL}: ${2:Type} = ${4:val}]]></content>
     <tabTrigger>const</tabTrigger>
     <scope>source.rust</scope>
     <description>const …: … = …</description>

--- a/enum.sublime-snippet
+++ b/enum.sublime-snippet
@@ -1,6 +1,6 @@
 <snippet>
     <content><![CDATA[enum ${1:Name} {
-    ${2:variant1}
+    ${2:Variant}
 }]]></content>
     <tabTrigger>enum</tabTrigger>
     <scope>source.rust</scope>

--- a/fn.sublime-snippet
+++ b/fn.sublime-snippet
@@ -1,6 +1,6 @@
 <snippet>
-	<content><![CDATA[fn ${1:name}(${2:arg}: ${3:typ}) -> ${4:ret} {
-	${5:// add code here}
+	<content><![CDATA[fn ${1:name}(${2:arg}: ${3:Type}) -> ${4:Ret} {
+	$0
 }]]></content>
 	<tabTrigger>fn</tabTrigger>
 	<scope>source.rust</scope>

--- a/struct.sublime-snippet
+++ b/struct.sublime-snippet
@@ -1,6 +1,6 @@
 <snippet>
     <content><![CDATA[struct ${1:Name} {
-    ${2:Field}: ${3:typ}
+    ${2:field}: ${3:Type}
 }]]></content>
     <tabTrigger>struct</tabTrigger>
     <scope>source.rust</scope>


### PR DESCRIPTION
Minor fixes to the naming of snippets i.e. `CONSTANT`, `field`, `Type`, `Constructor`.