### PR TITLE
Updating snippets

### DIFF
--- a/snippets/else.sublime-snippet
+++ b/snippets/else.sublime-snippet
@@ -1,6 +1,6 @@
 <snippet>
     <content><![CDATA[else {
-    ${1:// add code here}
+    ${1:unimplemented!();}
 }]]></content>
     <tabTrigger>else</tabTrigger>
     <scope>source.rust</scope>

--- a/snippets/enum.sublime-snippet
+++ b/snippets/enum.sublime-snippet
@@ -1,5 +1,6 @@
 <snippet>
-    <content><![CDATA[enum ${1:Name} {
+    <content><![CDATA[#[derive(Debug)]
+enum ${1:Name} {
     ${2:Variant1},
     ${3:Variant2},
 }]]></content>

--- a/snippets/fn.sublime-snippet
+++ b/snippets/fn.sublime-snippet
@@ -1,6 +1,6 @@
 <snippet>
     <content><![CDATA[fn ${1:name}(${2:arg}: ${3:Type}) -> ${4:RetType} {
-    ${5:// add code here}
+    ${5:unimplemented!();}
 }]]></content>
     <tabTrigger>fn</tabTrigger>
     <scope>source.rust</scope>

--- a/snippets/for.sublime-snippet
+++ b/snippets/for.sublime-snippet
@@ -1,6 +1,6 @@
 <snippet>
     <content><![CDATA[for ${1:pat} in ${2:expr} {
-    ${3:// add code here}
+    ${3:unimplemented!();}
 }]]></content>
     <tabTrigger>for</tabTrigger>
     <scope>source.rust</scope>

--- a/snippets/if-let.sublime-snippet
+++ b/snippets/if-let.sublime-snippet
@@ -1,6 +1,6 @@
 <snippet>
     <content><![CDATA[if let ${1:Some(pat)} = ${2:expr} {
-    ${2:// add code here}
+    ${2:unimplemented!();}
 }]]></content>
     <tabTrigger>if-let</tabTrigger>
     <scope>source.rust</scope>

--- a/snippets/if.sublime-snippet
+++ b/snippets/if.sublime-snippet
@@ -1,6 +1,6 @@
 <snippet>
     <content><![CDATA[if ${1:condition} {
-    ${2:// add code here}
+    ${2:unimplemented!();}
 }]]></content>
     <tabTrigger>if</tabTrigger>
     <scope>source.rust</scope>

--- a/snippets/loop.sublime-snippet
+++ b/snippets/loop.sublime-snippet
@@ -1,6 +1,6 @@
 <snippet>
     <content><![CDATA[loop {
-    ${2:// add code here}
+    ${2:unimplemented!();}
 }]]></content>
     <tabTrigger>loop</tabTrigger>
     <scope>source.rust</scope>

--- a/snippets/main.sublime-snippet
+++ b/snippets/main.sublime-snippet
@@ -1,6 +1,6 @@
 <snippet>
     <content><![CDATA[fn main() {
-    ${1:// add code here}
+    ${1:unimplemented!();}
 }]]></content>
     <tabTrigger>main</tabTrigger>
     <scope>source.rust</scope>

--- a/snippets/struct.sublime-snippet
+++ b/snippets/struct.sublime-snippet
@@ -1,5 +1,6 @@
 <snippet>
-    <content><![CDATA[struct ${1:Name} {
+    <content><![CDATA[#[derive(Debug)]
+struct ${1:Name} {
     ${2:field}: ${3:Type}
 }]]></content>
     <tabTrigger>struct</tabTrigger>

--- a/snippets/test.sublime-snippet
+++ b/snippets/test.sublime-snippet
@@ -2,7 +2,7 @@
     <content><![CDATA[
 #[test]
 fn ${1:name}() {
-    ${2:// add code here}
+    ${2:unimplemented!();}
 }]]></content>
     <tabTrigger>test</tabTrigger>
     <scope>source.rust</scope>

--- a/snippets/while-let.sublime-snippet
+++ b/snippets/while-let.sublime-snippet
@@ -1,6 +1,6 @@
 <snippet>
     <content><![CDATA[while let ${1:Some(pat)} = ${2:expr} {
-    ${2:// add code here}
+    ${2:unimplemented!();}
 }]]></content>
     <tabTrigger>while-let</tabTrigger>
     <scope>source.rust</scope>

--- a/snippets/while.sublime-snippet
+++ b/snippets/while.sublime-snippet
@@ -1,6 +1,6 @@
 <snippet>
     <content><![CDATA[while ${1:condition} {
-    ${2:// add code here}
+    ${2:unimplemented!();}
 }]]></content>
     <tabTrigger>while</tabTrigger>
     <scope>source.rust</scope>


### PR DESCRIPTION
Change `// add code here` comments by unimplemented macros. It make sure the snippet can compile right after being expanded.

Adding the `#[derive(Debug)]` to struct and enum is, I think, a good idea because it is recommanded that every struct implement this trait because it help for debugging. Bonus : it also inform every users that the derive annotation exist.