### PR TITLE
Ignore non-file locations in error log

### DIFF
--- a/Cargo.sublime-build
+++ b/Cargo.sublime-build
@@ -1,7 +1,7 @@
 {
     "cmd": ["cargo", "build"],
     "selector": "source.rust",
-    "file_regex": "^(.*?):([0-9]+):([0-9]+):\\s[0-9]+:[0-9]+\\s(.*)$",
+    "file_regex": "^([^<].*?):([0-9]+):([0-9]+):\\s[0-9]+:[0-9]+\\s(.*)$",
     "syntax": "Packages/Makefile/Make.build-language",
 
     "variants": [


### PR DESCRIPTION
When error is met during macro expansion, there are lines like
"<std macros>:6:6: 6:32: ..." in error log. Sublime tries to interpret
"<std macros>" as file name when you invoke "Next result" and opens
new empty tab for it.

This change will cause Sublime to ignore file names starting with '<'.