### PR TITLE
remove makefile reference

### DIFF
--- a/Cargo.sublime-build
+++ b/Cargo.sublime-build
@@ -2,7 +2,6 @@
     "cmd": ["cargo", "build"],
     "selector": "source.rust",
     "file_regex": "^(.*?):([0-9]+):([0-9]+):\\s[0-9]+:[0-9]+\\s(.*)$",
-    "syntax": "Packages/Makefile/Make.build-language",
 
     "variants": [
         {


### PR DESCRIPTION
the Cargo .sublime-build file references the Makefile syntax by file path and causes an error in Sublime Text 3 build 3099 as the file doesn't exist any more. Not sure that this was doing anything useful before as syntax isn't a feature listed in build-systems http://sublimetext.info/docs/en/reference/build_systems.html