### PR TITLE
Create and use use own cargo output syntax file

### DIFF
--- a/Cargo.build-language
+++ b/Cargo.build-language
@@ -1,0 +1,45 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<plist version="1.0">
+<dict>
+    <key>name</key>
+    <string>Cargo Build Results</string>
+    <key>patterns</key>
+    <array>
+        <dict>
+            <key>match</key>
+            <string>^(..[^:\n]*):([0-9]+):?([0-9]+)?:? </string>
+            <key>name</key>
+            <string>entity.name.filename</string>
+            <!--
+            <key>captures</key>
+            <dict>
+                <key>2</key>
+                <dict>
+                    <key>name</key>
+                    <string>constant.numeric.line-number</string>
+                </dict>
+                <key>3</key>
+                <dict>
+                    <key>name</key>
+                    <string>constant.numeric.column-number</string>
+                </dict>
+            </dict>
+            -->
+        </dict>
+        <dict>
+            <key>match</key>
+            <string>\berror: </string>
+            <key>name</key>
+            <string>message.error</string>
+        </dict>
+        <dict>
+            <key>match</key>
+            <string>^\[.+\]$</string>
+            <key>name</key>
+            <string>comment</string>
+        </dict>
+    </array>
+    <key>scopeName</key>
+    <string>source.build_results</string>
+</dict>
+</plist>

--- a/Cargo.sublime-build
+++ b/Cargo.sublime-build
@@ -2,7 +2,7 @@
     "cmd": ["cargo", "build"],
     "selector": "source.rust",
     "file_regex": "^(.*?):([0-9]+):([0-9]+):\\s[0-9]+:[0-9]+\\s(.*)$",
-    "syntax": "Packages/Makefile/Make.build-language",
+    "syntax": "Cargo.build-language",
 
     "variants": [
         {


### PR DESCRIPTION
The current syntax highlighting though simple uses the file from the default packages for the Makefile output syntax. This is removed in newer sublime versions so we should use are own one (which can be improved also)