### PR TITLE
Add highlighting and jumping to test failures for test output

### DIFF
--- a/Cargo.build-language
+++ b/Cargo.build-language
@@ -28,6 +28,72 @@
         </dict>
         <dict>
             <key>match</key>
+            <string>\bFAILED\b</string>
+            <key>name</key>
+            <string>invalid</string>
+        </dict>
+        <dict>
+            <key>match</key>
+            <string>^note:</string>
+            <key>name</key>
+            <string>variable.parameter</string>
+        </dict>
+        <dict>
+            <key>match</key>
+            <string>^test result:</string>
+            <key>name</key>
+            <string>variable.parameter</string>
+        </dict>
+        <dict>
+            <key>match</key>
+            <string>^failures:</string>
+            <key>name</key>
+            <string>message.error</string>
+        </dict>
+        <dict>
+            <key>match</key>
+            <string>\bok\b</string>
+            <key>name</key>
+            <string>markup.inserted.diff</string>
+        </dict>
+        <dict>
+            <key>match</key>
+            <string>\bhelp:[\s\S]+$</string>
+            <key>name</key>
+            <string>markup.inserted.diff</string>
+        </dict>
+        <dict>
+            <key>match</key>
+            <string>^\s{4}[\S\s]+,\s([\w,\s-]+\.[A-Za-z]{2}):([0-9]+)</string>
+            <key>name</key>
+            <string>message.error</string>
+        </dict>
+        <dict>
+            <key>match</key>
+            <string>[0-9]+ passed</string>
+            <key>name</key>
+            <string>markup.inserted.diff</string>
+        </dict>
+        <dict>
+            <key>match</key>
+            <string>[1-9][0-9]* failed</string>
+            <key>name</key>
+            <string>message.error</string>
+        </dict>
+        <dict>
+            <key>match</key>
+            <string>[1-9][0-9]* ignored</string>
+            <key>name</key>
+            <string>markup.changed.diff</string>
+        </dict>
+        <dict>
+            <key>match</key>
+            <string>[1-9][0-9]* measured</string>
+            <key>name</key>
+            <string>support.constant</string>
+        </dict>
+        <dict>
+            <key>match</key>
             <string>\berror: </string>
             <key>name</key>
             <string>message.error</string>

--- a/Cargo.sublime-build
+++ b/Cargo.sublime-build
@@ -1,7 +1,7 @@
 {
     "shell_cmd": "cargo build",
     "selector": "source.rust",
-    "file_regex": "[ \\t]*-->[ \\t]*(.*?):([0-9]+):([0-9]+)$",
+    "file_regex": "(?|(^.*?):([0-9]+):([0-9]+):\\s[0-9]+:[0-9]+\\s(.*)$|([[a-zA-Z]+\\.[A-Za-z]{2}):([0-9]+)$)",
     "syntax": "Cargo.build-language",
     "osx":
     {
@@ -24,6 +24,14 @@
         {
             "shell_cmd": "cargo clean",
             "name": "Clean"
-        }
+        },
+        {
+            "cmd": ["cargo", "build", "--release"],
+            "name": "Release"
+        },
+        {
+            "cmd": ["cargo", "clippy"],
+            "name": "Clippy"
+        },
     ]
 }

--- a/Cargo.sublime-build
+++ b/Cargo.sublime-build
@@ -26,11 +26,11 @@
             "name": "Clean"
         },
         {
-            "cmd": ["cargo", "build", "--release"],
+            "shell_cmd": ["cargo", "build", "--release"],
             "name": "Release"
         },
         {
-            "cmd": ["cargo", "clippy"],
+            "shell_cmd": ["cargo", "clippy"],
             "name": "Clippy"
         },
     ]

--- a/Cargo.sublime-build
+++ b/Cargo.sublime-build
@@ -26,11 +26,11 @@
             "name": "Clean"
         },
         {
-            "shell_cmd": ["cargo", "build", "--release"],
+            "shell_cmd": "cargo build --release",
             "name": "Release"
         },
         {
-            "shell_cmd": ["cargo", "clippy"],
+            "shell_cmd": "cargo clippy",
             "name": "Clippy"
         },
     ]

--- a/Cargo.sublime-build
+++ b/Cargo.sublime-build
@@ -1,7 +1,7 @@
 {
     "shell_cmd": "cargo build",
     "selector": "source.rust",
-    "file_regex": "(?|(^.*?):([0-9]+):([0-9]+):\\s[0-9]+:[0-9]+\\s(.*)$|([[a-zA-Z]+\\.[A-Za-z]{2}):([0-9]+)$)",
+    "file_regex": "(?|(^[^<].*?):([0-9]+):([0-9]+):\\s[0-9]+:[0-9]+\\s(.*)$|([[a-zA-Z]+\\.[A-Za-z]{2}):([0-9]+)$)",
     "syntax": "Cargo.build-language",
     "osx":
     {


### PR DESCRIPTION
This PR adds

`cargo test` output highlighting:
- `note:`
- `test result:`
- a passed test
- a failed test
- failed test source line (this is **clickable**, jumps to source)
- summary line, total number of passed tests
- summary line, total number of failed tests if > 0
- summary line, total number of ignored tests if > 0
- summary line, total number of measured tests if > 0



New build commands:
- `cargo build --release`
- `cargo clippy`

Bug fixes:
- Don't treat `<std macros>` as a file name.

My choice of entity to trigger various highlights is probably questionable, but they're a complete 🚮🔥 anyway. @dten what do you think?