### PR TITLE
Add Cargo-Doc, Cargo-Release and Cargo-Update to the Cargo.sublime-build

### DIFF
--- a/Cargo.sublime-build
+++ b/Cargo.sublime-build
@@ -18,6 +18,18 @@
             "name": "Bench"
         },
         {
+            "cmd": ["cargo", "release"],
+            "name": "Release"
+        },
+        {
+            "cmd": ["cargo", "doc", "--no-deps"],
+            "name": "Doc"
+        },
+        {
+            "cmd": ["cargo", "update"],
+            "name": "Update"
+        },
+        {
             "cmd": ["cargo", "clean"],
             "name": "Clean"
         }


### PR DESCRIPTION
To skip manually writing these commands in shell.

Cargo-Doc with `--no-deps` because it is most common choice, I guess.
