### PR TITLE
Fix Cargo.sublime-build path for OSX

### DIFF
--- a/Cargo.sublime-build
+++ b/Cargo.sublime-build
@@ -3,6 +3,10 @@
     "selector": "source.rust",
     "file_regex": "^(.*?):([0-9]+):([0-9]+):\\s[0-9]+:[0-9]+\\s(.*)$",
     "syntax": "Cargo.build-language",
+    "osx":
+    {
+        "path": "/usr/bin:/bin:/usr/sbin:/sbin:/usr/local/bin"
+    },
 
     "variants": [
         {


### PR DESCRIPTION
As of now Rust.sublime-build and Cargo.sublime-build have different $PATH set although they are usually located in the same places.
This change just adds additional directories to the default $PATH directories.