### PR TITLE
first stab at adding syntax checking on save similar to GoSublime

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,20 @@ instructions.
 
 Open the palette (`control+shift+P` or `command+shift+P`) in Sublime Text
 and select `Package Control: Install Package` and then select `Rust` from
-the list. That's it.
+the list. That's it.  
+
+# Syntax Checking
+The sublime-rust package now comes with syntax checking.  
+This relies on Cargo and Rust (tested with >= 1.8.0) being installed and on your system path.
+Once installed sublime will make a call to cargo to syntax check the project you're on then will feedback any line numbers which are failing by displaying a dot within the gutter of the editor. By clicking the dot you should get a tooltip of the error displayed.  
+This feature is in Alpha stage and not on by default, so you will need to change the value of ```rust_syntax_checking``` to true within your settings (see Settings).   
+Here is an example:   
+![preview](https://cloud.githubusercontent.com/assets/936006/15657328/b90c2636-26a7-11e6-8c35-ff6dcd880bac.gif)
+
+## Settings
+You can customize the behaviour of sublime-rust by creating a settings file in your User package. This can be accessed from within SublimeText by going to the menu Preferences > Browse Packages.... Create a file named Rust.sublime-settings or alternatively copy the default settings file Packages/sublime-rust/Rust.sublime-settings to your User package and edit it to your liking.
+
+Note: File names are case-sensitive on some platforms (e.g. Linux) so the file name should be exactly Rust.sublime-settings with capitalization preserved.
 
 ## Development
 

--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ the list. That's it.
 
 ## Syntax Checking
 The sublime-rust package now comes with syntax checking.  
-This relies on Cargo and Rust (tested with >= 1.8.0) being installed and on your system path.
+This relies on Cargo and Rust (>= 1.8.0) being installed and on your system path.
 Once installed sublime will make a call to cargo to syntax check the project you're on then will feedback any line numbers which are failing by displaying a dot within the gutter of the editor. By clicking the dot you should get a tooltip of the error displayed.  
 This feature is in Alpha stage and not on by default, so you will need to change the value of ```rust_syntax_checking``` to true within your settings (see Settings).   
 Here is an example:   

--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ Open the palette (`control+shift+P` or `command+shift+P`) in Sublime Text
 and select `Package Control: Install Package` and then select `Rust` from
 the list. That's it.  
 
-# Syntax Checking
+## Syntax Checking
 The sublime-rust package now comes with syntax checking.  
 This relies on Cargo and Rust (tested with >= 1.8.0) being installed and on your system path.
 Once installed sublime will make a call to cargo to syntax check the project you're on then will feedback any line numbers which are failing by displaying a dot within the gutter of the editor. By clicking the dot you should get a tooltip of the error displayed.  

--- a/README.md
+++ b/README.md
@@ -21,6 +21,11 @@ The sublime-rust package now comes with syntax checking.
 This relies on Cargo and Rust (>= 1.8.0) being installed and on your system path.
 Once installed sublime will make a call to cargo to syntax check the project you're on then will feedback any line numbers which are failing by displaying a dot within the gutter of the editor. By clicking the dot you should get a tooltip of the error displayed.  
 This feature is in Alpha stage and not on by default, so you will need to change the value of ```rust_syntax_checking``` to true within your settings (see Settings).   
+```json
+{
+	"rust_syntax_checking": true
+}
+```
 Here is an example:   
 ![preview](https://cloud.githubusercontent.com/assets/936006/15657328/b90c2636-26a7-11e6-8c35-ff6dcd880bac.gif)
 

--- a/Rust.sublime-settings
+++ b/Rust.sublime-settings
@@ -1,0 +1,4 @@
+{
+	// Enable the syntax checking plugin, which will highlight any errors during build
+	"rust_syntax_checking": false
+}

--- a/plugin.py
+++ b/plugin.py
@@ -2,18 +2,50 @@ import sublime, sublime_plugin
 import subprocess
 import os
 import re
+
+
+def is_event_on_gutter(view, event):
+    """Determine if a mouse event points to the gutter.
+
+    Because this is inapplicable for empty lines,
+    returns `None` to let the caller decide on what do to.
+    """
+    original_pt = view.window_to_text((event["x"], event["y"]))
+    if view.rowcol(original_pt)[1] != 0:
+        return False
+
+    # If the line is empty,
+    # we will always get the same textpos
+    # regardless of x coordinate.
+    # Return `None` in this case and let the caller decide.
+    if view.line(original_pt).empty():
+        return None
+
+    # ST will put the caret behind the first character
+    # if we click on the second half of the char.
+    # Use view.em_width() / 2 to emulate this.
+    adjusted_pt = view.window_to_text((event["x"] + view.em_width() / 2, event["y"]))
+    if adjusted_pt != original_pt:
+        return False
+
+    return original_pt
+
+
+def lol():
+    print('lol')
   
-class rustPluginEvents(sublime_plugin.EventListener):
+class rustPluginSyntaxCheckEvent(sublime_plugin.EventListener):
 
     def __init__(self):
         # This will fetch the line number that failed from the $ cargo run output
         # We could fetch multiple lines but this is a start
         # Lets compile it here so we don't need to compile on every save
-        self.lineRegex = re.compile(b"rs:(\d+)")
+        self.lineRegex = re.compile(b"rs:(\d+).*error\:\s(.*)")
+        self.errors = {}
 
-    def get_line_number(self, output):
+    def get_line_number_and_msg(self, output):
         if self.lineRegex.search(output):
-            return self.lineRegex.search(output).group(1)
+            return self.lineRegex.search(output)
 
     def draw_dots_to_screen(self, view, line_num):
         line_num -= 1 # line numbers are zero indexed on the sublime API, so take off 1
@@ -22,14 +54,25 @@ class rustPluginEvents(sublime_plugin.EventListener):
 
     def on_post_save_async(self, view):  
         if "source.rust" in view.scope_name(0): # Are we in rust scope?
+            self.errors = {} # reset on every save
             os.chdir(os.path.dirname(view.file_name()))
             # shell=True is needed to stop the window popping up, although it looks like this is needed: http://stackoverflow.com/questions/3390762/how-do-i-eliminate-windows-consoles-from-spawned-processes-in-python-2-7
             # We only care about stderr
-            cargoRun = subprocess.Popen('cargo rustc --verbose -- -Zno-trans --verbose', shell=True, stderr=subprocess.PIPE, stdout=subprocess.PIPE)
+            cargoRun = subprocess.Popen('cargo rustc -- -Zno-trans', shell=True, stderr=subprocess.PIPE, stdout=subprocess.PIPE)
             output = cargoRun.communicate()
             if (output):
-                line = self.get_line_number(output[1]) 
+                result = self.get_line_number_and_msg(output[1])
+                line = int(result.group(1))
+                msg = str(result.group(2))
                 if (line):
+                    self.errors[line] = msg
                     self.draw_dots_to_screen(view, int(line))
                 else:
                     view.erase_regions('buildError')
+
+
+    def on_text_command(self, view, command_name, args):
+        event = args['event']
+        if (is_event_on_gutter(view, event)): 
+            line_clicked = view.rowcol(is_event_on_gutter(view, event))[0] + 1
+            view.show_popup_menu([self.errors[line_clicked]], lol)

--- a/plugin.py
+++ b/plugin.py
@@ -9,7 +9,7 @@ class rustPluginEvents(sublime_plugin.EventListener):
         # This will fetch the line number that failed from the $ cargo run output
         # We could fetch multiple lines but this is a start
         # Lets compile it here so we don't need to compile on every save
-        self.lineRegex = re.compile(b"rs:(\d)")
+        self.lineRegex = re.compile(b"rs:(\d+)")
 
     def get_line_number(self, output):
         if self.lineRegex.search(output):
@@ -25,7 +25,7 @@ class rustPluginEvents(sublime_plugin.EventListener):
             os.chdir(os.path.dirname(view.file_name()))
             # shell=True is needed to stop the window popping up, although it looks like this is needed: http://stackoverflow.com/questions/3390762/how-do-i-eliminate-windows-consoles-from-spawned-processes-in-python-2-7
             # We only care about stderr
-            cargoRun = subprocess.Popen(['cargo', 'run'], shell=True, stderr=subprocess.PIPE)
+            cargoRun = subprocess.Popen(['cargo', 'rustc', '--', '-Zno-trans'], shell=True, stderr=subprocess.PIPE)
             output = cargoRun.communicate()[1] 
             if (output):
                 line = self.get_line_number(output)

--- a/plugin.py
+++ b/plugin.py
@@ -52,8 +52,8 @@ class rustPluginSyntaxCheckEvent(sublime_plugin.EventListener):
         view.add_regions('buildError', [view.line(view.text_point(line_num, 0))], 'comment', 'dot', sublime.HIDDEN)
 
 
-    def on_post_save_async(self, view):  
-        if "source.rust" in view.scope_name(0): # Are we in rust scope?
+    def on_post_save_async(self, view):
+        if "source.rust" in view.scope_name(0) and view.settings().get('rust_syntax_checking'): # Are we in rust scope and is it switched on?
             self.errors = {} # reset on every save
             view.erase_regions('buildError')
             os.chdir(os.path.dirname(view.file_name()))

--- a/plugin.py
+++ b/plugin.py
@@ -1,0 +1,35 @@
+import sublime, sublime_plugin
+import subprocess
+import os
+import re
+  
+class rustPluginEvents(sublime_plugin.EventListener):
+
+    def __init__(self):
+        # This will fetch the line number that failed from the $ cargo run output
+        # We could fetch multiple lines but this is a start
+        # Lets compile it here so we don't need to compile on every save
+        self.lineRegex = re.compile(b"rs:(\d)")
+
+    def get_line_number(self, output):
+        if self.lineRegex.search(output):
+            return self.lineRegex.search(output).group(1)
+
+    def draw_dots_to_screen(self, view, line_num):
+        line_num -= 1 # line numbers are zero indexed on the sublime API, so take off 1
+        view.add_regions('buildError', [view.line(view.text_point(line_num, 0))], 'comment', 'dot', sublime.HIDDEN)
+
+
+    def on_post_save(self, view):  
+        if "source.rust" in view.scope_name(0): # Are we in rust scope?
+            os.chdir(os.path.dirname(view.file_name()))
+            # shell=True is needed to stop the window popping up, although it looks like this is needed: http://stackoverflow.com/questions/3390762/how-do-i-eliminate-windows-consoles-from-spawned-processes-in-python-2-7
+            # We only care about stderr
+            cargoRun = subprocess.Popen(['cargo', 'run'], shell=True, stderr=subprocess.PIPE)
+            output = cargoRun.communicate()[1] 
+            if (output):
+                line = self.get_line_number(output)
+                if (line):
+                    self.draw_dots_to_screen(view, int(line))
+                else:
+                    view.erase_regions('buildError')

--- a/plugin.py
+++ b/plugin.py
@@ -40,7 +40,7 @@ class rustPluginSyntaxCheckEvent(sublime_plugin.EventListener):
         # This will fetch the line number that failed from the $ cargo run output
         # We could fetch multiple lines but this is a start
         # Lets compile it here so we don't need to compile on every save
-        self.lineRegex = re.compile(b"rs:(\d+).*error\:\s(.*)")
+        self.lineRegex = re.compile(b"(\w*\.rs):(\d+).*error\:\s(.*)")
         self.errors = {}
 
     def get_line_number_and_msg(self, output):
@@ -63,9 +63,11 @@ class rustPluginSyntaxCheckEvent(sublime_plugin.EventListener):
             output = cargoRun.communicate()
             result = self.get_line_number_and_msg(output[1]) if len(output) > 1 else False
             if (result):
-                line = int(result.group(1))
-                msg = result.group(2).decode('utf-8')
-                if (line):
+                fileName = result.group(1).decode('utf-8')
+                view_filename = os.path.basename(view.file_name())
+                line = int(result.group(2))
+                msg = result.group(3).decode('utf-8')
+                if (fileName == view_filename and line):
                     self.errors[line] = msg
                     self.draw_dots_to_screen(view, int(line))
                 else:

--- a/plugin.py
+++ b/plugin.py
@@ -20,15 +20,15 @@ class rustPluginEvents(sublime_plugin.EventListener):
         view.add_regions('buildError', [view.line(view.text_point(line_num, 0))], 'comment', 'dot', sublime.HIDDEN)
 
 
-    def on_post_save(self, view):  
+    def on_post_save_async(self, view):  
         if "source.rust" in view.scope_name(0): # Are we in rust scope?
             os.chdir(os.path.dirname(view.file_name()))
             # shell=True is needed to stop the window popping up, although it looks like this is needed: http://stackoverflow.com/questions/3390762/how-do-i-eliminate-windows-consoles-from-spawned-processes-in-python-2-7
             # We only care about stderr
-            cargoRun = subprocess.Popen(['cargo', 'rustc', '--', '-Zno-trans'], shell=True, stderr=subprocess.PIPE)
-            output = cargoRun.communicate()[1] 
+            cargoRun = subprocess.Popen('cargo rustc --verbose -- -Zno-trans --verbose', shell=True, stderr=subprocess.PIPE, stdout=subprocess.PIPE)
+            output = cargoRun.communicate()
             if (output):
-                line = self.get_line_number(output)
+                line = self.get_line_number(output[1]) 
                 if (line):
                     self.draw_dots_to_screen(view, int(line))
                 else:


### PR DESCRIPTION
HI guys
I really liked the syntax checking on save within GoSublime.
So i had a go at trying it for Rust.

Under the hood all this plugin does is call "cargo run" in the same directory the file is in, if there's any errors it will try and parse out the first line number, then return that back to sublime.

It would be nice if some sublime users could take a look at my PR and tell me what they think needs adding or their thoughts.

here is a demo
Thanks Jason

![testingpr](https://cloud.githubusercontent.com/assets/936006/15608781/fd8485d8-2413-11e6-8dcf-ead623661278.gif)
