### PR TITLE
Correctly parse new build error message file/line

### DIFF
--- a/Cargo.sublime-build
+++ b/Cargo.sublime-build
@@ -1,7 +1,7 @@
 {
     "cmd": ["cargo", "build"],
     "selector": "source.rust",
-    "file_regex": "^(.*?):([0-9]+):([0-9]+):\\s[0-9]+:[0-9]+\\s(.*)$",
+    "file_regex": "  --> ([^:]+):([0-9]+):([0-9]+)$",
     "syntax": "Cargo.build-language",
 
     "variants": [

--- a/Cargo.sublime-build
+++ b/Cargo.sublime-build
@@ -1,7 +1,7 @@
 {
     "cmd": ["cargo", "build"],
     "selector": "source.rust",
-    "file_regex": "  --> ([^:]+):([0-9]+):([0-9]+)$",
+    "file_regex": "--> ([^:]+):([0-9]+):([0-9]+)$",
     "syntax": "Cargo.build-language",
 
     "variants": [

--- a/Rust.sublime-build
+++ b/Rust.sublime-build
@@ -1,7 +1,7 @@
 {
     "cmd": ["rustc", "$file"],
     "selector": "source.rust",
-    "file_regex": "^(.*?):([0-9]+):([0-9]+):\\s[0-9]+:[0-9]+\\s(.*)$",
+    "file_regex": "  --> ([^:]+):([0-9]+):([0-9]+)$",
     "osx":
     {
         "path": "/usr/bin:/bin:/usr/sbin:/sbin:/usr/local/bin"

--- a/RustComment.tmPreferences
+++ b/RustComment.tmPreferences
@@ -34,6 +34,18 @@
 				<key>value</key>
 				<string>no</string>
 			</dict>
+			<dict>
+	            <key>name</key>
+	            <string>TM_COMMENT_START_3</string>
+	            <key>value</key>
+	            <string>/// </string>
+	        </dict>
+	        <dict>
+	            <key>name</key>
+	            <string>TM_COMMENT_START_4</string>
+	            <key>value</key>
+	            <string>//! </string>
+	        </dict>
 		</array>
 	</dict>
 	<key>uuid</key>


### PR DESCRIPTION
I'm not sure how rock-solid the regex will be in the future but it works for now.

Also adds doc comments to the known comment types (for use by plugins that automatically format lines, etc.).