### PR TITLE
Experimental support for the new error format

### DIFF
--- a/Main.sublime-menu
+++ b/Main.sublime-menu
@@ -1,0 +1,34 @@
+[
+    {
+
+        "id": "preferences",
+        "children":
+        [
+            {
+                "caption": "Package Settings",
+                "mnemonic": "P",
+                "id": "package-settings",
+                "children":
+                [
+                    {
+                        "caption": "Rust",
+                        "children":
+                        [
+                            {
+                                "command": "open_file",
+                                "args": {"file": "${packages}/Rust/Rust.sublime-settings"},
+                                "caption": "Settings – Default"
+                            },
+                            {
+                                "command": "open_file",
+                                "args": {"file": "${packages}/User/Rust.sublime-settings"},
+                                "caption": "Settings – User"
+                            }
+                        ]
+                    }
+                ]
+            }
+        ]
+    }
+
+]

--- a/Rust.sublime-settings
+++ b/Rust.sublime-settings
@@ -1,4 +1,4 @@
 {
 	// Enable the syntax checking plugin, which will highlight any errors during build
-	"rust_syntax_checking": false
+	"rust_syntax_checking": true
 }

--- a/plugin.py
+++ b/plugin.py
@@ -51,7 +51,7 @@ class rustPluginSyntaxCheckEvent(sublime_plugin.EventListener):
             output = cargoRun.communicate()
             view_filename = view.file_name()
 
-            for line in output[1].split(os.linesep):
+            for line in output[1].split('\n'):
                 if line == '' or line[0] != '{':
                     continue
                 info = json.loads(line)

--- a/plugin.py
+++ b/plugin.py
@@ -4,34 +4,6 @@ import os
 import html
 import json
 
-
-def is_event_on_gutter(view, event):
-    """Determine if a mouse event points to the gutter.
-
-    Because this is inapplicable for empty lines,
-    returns `None` to let the caller decide on what do to.
-    """
-    original_pt = view.window_to_text((event["x"], event["y"]))
-    if view.rowcol(original_pt)[1] != 0:
-        return False
-
-    # If the line is empty,
-    # we will always get the same textpos
-    # regardless of x coordinate.
-    # Return `None` in this case and let the caller decide.
-    if view.line(original_pt).empty():
-        return None
-
-    # ST will put the caret behind the first character
-    # if we click on the second half of the char.
-    # Use view.em_width() / 2 to emulate this.
-    adjusted_pt = view.window_to_text((event["x"] + view.em_width() / 2, event["y"]))
-    if adjusted_pt != original_pt:
-        return False
-
-    return original_pt
-
-
 class rustPluginSyntaxCheckEvent(sublime_plugin.EventListener):
 
     def on_post_save_async(self, view):

--- a/plugin.py
+++ b/plugin.py
@@ -1,7 +1,6 @@
 import sublime, sublime_plugin
 import subprocess
 import os
-import re
 import html
 import json
 
@@ -36,7 +35,10 @@ def is_event_on_gutter(view, event):
 class rustPluginSyntaxCheckEvent(sublime_plugin.EventListener):
 
     def on_post_save_async(self, view):
-        if "source.rust" in view.scope_name(0) and view.settings().get('rust_syntax_checking'): # Are we in rust scope and is it switched on?
+        # Are we in rust scope and is it switched on?
+        # We use phantoms which were added in 3118
+        enabled = view.settings().get('rust_syntax_checking') and int(sublime.version()) >= 3118
+        if "source.rust" in view.scope_name(0) and enabled:
             self.errors = {} # reset on every save
             view.erase_regions('buildError')
             os.chdir(os.path.dirname(view.file_name()))

--- a/plugin.py
+++ b/plugin.py
@@ -20,7 +20,6 @@ class rustPluginSyntaxCheckEvent(sublime_plugin.EventListener):
             )
             output = cargoRun.communicate()
             view.erase_phantoms('buildErrorLine')
-            view_filename = view.file_name()
 
             for line in output[1].split('\n'):
                 if line == '' or line[0] != '{':
@@ -29,40 +28,51 @@ class rustPluginSyntaxCheckEvent(sublime_plugin.EventListener):
                 # Can't show without spans
                 if len(info['spans']) == 0:
                     continue
+                self.add_error_phantom(view, info)
 
-                msg = info['message']
-                base_color = "#F00"
-                if info['level'] != "error":
-                    base_color = "#FF0"
+    def add_error_phantom(self, view, info):
+        msg = info['message']
 
-                for span in info['spans']:
-                    if not view_filename.endswith(span['file_name']):
-                        continue
-                    color = base_color
-                    char = "^"
-                    if not span['is_primary']:
-                        color = "#0FF"
-                        char = "-"
-                    area = sublime.Region(
-                        view.text_point(span['line_start'] - 1, span['column_start'] - 1),
-                        view.text_point(span['line_end'] - 1, span['column_end'] - 1)
-                    )
-                    underline = char * (span['column_end'] - span['column_start'])
-                    label = span['label']
-                    if not label:
-                        label = ''
-                    view.add_phantom(
-                        'buildErrorLine', area,
-                        "<span style=\"color:{}\">{} {}</span>"
-                        .format(color, underline, html.escape(label, quote=False)),
-                        sublime.LAYOUT_BELOW
-                    )
-                    if span['is_primary']:
-                        view.add_phantom(
-                            'buildErrorLine', area,
-                            "<span style=\"color:{}\">{}</span>"
-                            .format(color,  html.escape(msg, quote=False)),
-                            sublime.LAYOUT_BELOW
-                        )
+        base_color = "#F00" # Error color
+        if info['level'] != "error":
+            # Warning color
+            base_color = "#FF0"
+
+        view_filename = view.file_name()
+        for span in info['spans']:
+            if not view_filename.endswith(span['file_name']):
+                continue
+            color = base_color
+            char = "^"
+            if not span['is_primary']:
+                # Non-primary spans are normally additional
+                # information to help understand the error.
+                color = "#0FF"
+                char = "-"
+            # Sublime text is 0 based whilst the line/column info from
+            # rust is 1 based.
+            area = sublime.Region(
+                view.text_point(span['line_start'] - 1, span['column_start'] - 1),
+                view.text_point(span['line_end'] - 1, span['column_end'] - 1)
+            )
+
+            underline = char * (span['column_end'] - span['column_start'])
+            label = span['label']
+            if not label:
+                label = ''
+
+            view.add_phantom(
+                'buildErrorLine', area,
+                "<span style=\"color:{}\">{} {}</span>"
+                .format(color, underline, html.escape(label, quote=False)),
+                sublime.LAYOUT_BELOW
+            )
+            if span['is_primary']:
+                view.add_phantom(
+                    'buildErrorLine', area,
+                    "<span style=\"color:{}\">{}</span>"
+                    .format(color,  html.escape(msg, quote=False)),
+                    sublime.LAYOUT_BELOW
+                )
 
 

--- a/plugin.py
+++ b/plugin.py
@@ -11,8 +11,6 @@ class rustPluginSyntaxCheckEvent(sublime_plugin.EventListener):
         # We use phantoms which were added in 3118
         enabled = view.settings().get('rust_syntax_checking') and int(sublime.version()) >= 3118
         if "source.rust" in view.scope_name(0) and enabled:
-            self.errors = {} # reset on every save
-            view.erase_regions('buildError')
             os.chdir(os.path.dirname(view.file_name()))
             # shell=True is needed to stop the window popping up, although it looks like this is needed: http://stackoverflow.com/questions/3390762/how-do-i-eliminate-windows-consoles-from-spawned-processes-in-python-2-7
             # We only care about stderr
@@ -20,9 +18,8 @@ class rustPluginSyntaxCheckEvent(sublime_plugin.EventListener):
                 shell=True, stderr=subprocess.PIPE, stdout=subprocess.PIPE,
                 universal_newlines = True
             )
-            view.erase_regions('buildError')
-            view.erase_phantoms('buildErrorLine')
             output = cargoRun.communicate()
+            view.erase_phantoms('buildErrorLine')
             view_filename = view.file_name()
 
             for line in output[1].split('\n'):


### PR DESCRIPTION
This is mostly a result of me playing around with the new json formatted error messages but I decided to PR it to see what was thought of it.

It requires the latest dev build of Sublime Text 3 so I don't really expect this to be pulled as it stands.

![](https://i.imgur.com/bZtwqk0.png)

This uses the phantom system to display error messages and hints inline with the code, i'm not sure how much I like this system but it seemed to be the nicest way I could think of displaying them.

I don't really do python so i'm sorry about the code