### PR TITLE
Fix if-let and while-let snippets

### DIFF
--- a/snippets/if-let.sublime-snippet
+++ b/snippets/if-let.sublime-snippet
@@ -1,6 +1,6 @@
 <snippet>
     <content><![CDATA[if let ${1:Some(pat)} = ${2:expr} {
-    ${2:unimplemented!();}
+    ${3:unimplemented!();}
 }]]></content>
     <tabTrigger>if-let</tabTrigger>
     <scope>source.rust</scope>

--- a/snippets/while-let.sublime-snippet
+++ b/snippets/while-let.sublime-snippet
@@ -1,6 +1,6 @@
 <snippet>
     <content><![CDATA[while let ${1:Some(pat)} = ${2:expr} {
-    ${2:unimplemented!();}
+    ${3:unimplemented!();}
 }]]></content>
     <tabTrigger>while-let</tabTrigger>
     <scope>source.rust</scope>


### PR DESCRIPTION
Both snippets accidentally used the $2 field twice, once for the expr and once for the body. This caused the body to be the same as the expr, which is almost never what the user would want. The body now uses the $3 field instead of $2.