### PR TITLE
Change "fmt" snippet to "format"

### DIFF
--- a/snippets/fmt.sublime-snippet
+++ b/snippets/fmt.sublime-snippet
@@ -1,6 +1,0 @@
-<snippet>
-    <content><![CDATA[fmt!("${1:\{${2::?}\}}"${1/([^\{])*(\{.*\})?.*/(?2:, :\);)/}$3${1/([^\{])*(\{.*\})?.*/(?2:\))/}]]></content>
-    <tabTrigger>fmt</tabTrigger>
-    <scope>source.rust</scope>
-    <description>fmt!(…)</description>
-</snippet>

--- a/snippets/format.sublime-snippet
+++ b/snippets/format.sublime-snippet
@@ -1,0 +1,6 @@
+<snippet>
+    <content><![CDATA[format!("${1:\{${2::?}\}}"${1/([^\{])*(\{.*\})?.*/(?2:, :\);)/}$3${1/([^\{])*(\{.*\})?.*/(?2:\))/}]]></content>
+    <tabTrigger>format</tabTrigger>
+    <scope>source.rust</scope>
+    <description>format!(…)</description>
+</snippet>


### PR DESCRIPTION
The `fmt!` syntax extension was deprecated and removed from Rust in 2013, in favor of the `format!` macro. The old fmt snippet works fine simply by changing "fmt" to "format".