### PR TITLE
Add syntax check support for projects with several build targets

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,8 +7,8 @@ it makes no attempt at supporting earlier incompatible versions.
 
 As of version 1.0.0 this package will no longer support Sublime Text 2. At the time of writing, ST3 is almost reaching stable, and we recommend migrating to that version if you need Rust Support.
 
-This package used to be called 'Rust', but as of version 3, Sublime now comes with Rust built-in.  The built-in version on Sublime is actually just a snapshot of this package [with some fixes](https://github.com/sublimehq/Packages/issues/178#issuecomment-197050427).   
-This package is still active and will continue to update and release, so if you want up to date features, and extra tools (such as syntax checking or building) we recommend using this package. It should override the default Rust within Sublime.   
+This package used to be called 'Rust', but as of version 3, Sublime now comes with Rust built-in.  The built-in version on Sublime is actually just a snapshot of this package [with some fixes](https://github.com/sublimehq/Packages/issues/178#issuecomment-197050427).
+This package is still active and will continue to update and release, so if you want up to date features, and extra tools (such as syntax checking or building) we recommend using this package. It should override the default Rust within Sublime.
 Syntax changes which happen here will eventually be pushed upstream into Sublime Core Packages repo, but extra features will stay here.
 
 For syntax highlighting for Cargo files. Its recommended installing this with the TOML package.
@@ -22,8 +22,8 @@ instructions.
 
 Open the palette (`control+shift+P` or `command+shift+P`) in Sublime Text
 and select `Package Control: Install Package` and then select `Rust Enhanced` from
-the list. That's it.   
-If you can't see `Rust Enhanced` try looking for `Rust`, we are changing names to `Rust Enhanced` but are waiting for [#5865](https://github.com/wbond/package_control_channel/pull/5865) to go through 
+the list. That's it.
+If you can't see `Rust Enhanced` try looking for `Rust`, we are changing names to `Rust Enhanced` but are waiting for [#5865](https://github.com/wbond/package_control_channel/pull/5865) to go through
 
 ## Features
 ### Go To Definition
@@ -47,22 +47,46 @@ Thanks to [urschrei](https://github.com/urschrei/)  we have Highlighting for:
 - total number of passed tests
 - total number of failed tests > 0
 - total number of ignored tests > 0
-- total number of measured tests > 0  
+- total number of measured tests > 0
 
-Example:   
+Example:
 ![highlight_rust_test](https://cloud.githubusercontent.com/assets/936006/19247437/3cf6e056-8f23-11e6-9bbe-d8c542287db6.png)
 
 ### Syntax Checking
-The sublime-rust package now comes with syntax checking.  
-This relies on Cargo and Rust (>= 1.8.0) being installed and on your system path. Plus Sublime Text >= 3118.   
-This feature is on by default, but you can adjust the the value of ```rust_syntax_checking``` within your settings (see Settings).   
+The sublime-rust package now comes with syntax checking.
+This relies on Cargo and Rust (>= 1.8.0) being installed and on your system path. Plus Sublime Text >= 3118.
+This feature is on by default, but you can adjust the the value of ```rust_syntax_checking``` within your settings (see Settings).
 ```json
 {
-	"rust_syntax_checking": true
+    "rust_syntax_checking": true
 }
 ```
-Here is an example:   
+Here is an example:
 ![testingrust](https://cloud.githubusercontent.com/assets/936006/18091147/938cb244-6ebf-11e6-9db1-b74e5bf4eebc.gif)
+
+Projects with multiple build targets are supported too. If a cargo project has several build targets, it's possible to specify mapping of source file names to the target to enable proper cargo's build target selection during syntax checking.
+Syntax checking is accomplished by command:
+```bash
+    cargo rustc {target} -- <some options>
+```
+where `{target}` is an empty string by default (perfectly works for cargo projects with only one build target). However, one can specify a certain target by updating plugin settings with the next section:
+```
+    "projects": {
+       // One entry per project. Keys are project names.
+       "my_cool_stuff": {
+           // Path to the project root dir without trailing /src.
+           "root": "/path/to/my/cool/stuff/project",
+
+           // Targets will be used to replace {target} part in the command.
+           // If no one target matches an, empty string will be used.
+           "targets": {
+               "bin/foo.rs": "--bin foo",  // format is "source_code_filename -> target_name"
+               "bin/bar.rs": "--bin bar",
+               "_default": "--lib"         // or "--bin main"
+           }
+       }
+   }
+```
 
 ## Settings
 You can customize the behaviour of sublime-rust by creating a settings file in your User package. This can be accessed from within SublimeText by going to the menu Preferences > Browse Packages.... Create a file named Rust.sublime-settings or alternatively copy the default settings file Packages/sublime-rust/Rust.sublime-settings to your User package and edit it to your liking.

--- a/Rust.sublime-settings
+++ b/Rust.sublime-settings
@@ -1,14 +1,14 @@
 {
-	// Enable the syntax checking plugin, which will highlight any errors during build
-	"rust_syntax_checking": true,
+    // Enable the syntax checking plugin, which will highlight any errors during build
+    "rust_syntax_checking": true,
 
-    // If your cargo project has several build targets, it's possible to specify mapping of 
+    // If your cargo project has several build targets, it's possible to specify mapping of
     // source code filenames to the target names to enable syntax checking.
     // "projects": {
     //     // One entry per project. Key is a project name.
     //     "my_cool_stuff": {
     //         "root": "/path/to/my/cool/stuff/project",  // without trailing /src
-    //         // Targets will be used to replace {target} part in the syntax check command: 
+    //         // Targets will be used to replace {target} part in the syntax check command:
     //         // command = 'cargo rustc {target} -- <some options>'. If no one target matches
     //         // an empty string will be used.
     //         "targets": {

--- a/Rust.sublime-settings
+++ b/Rust.sublime-settings
@@ -1,4 +1,21 @@
 {
 	// Enable the syntax checking plugin, which will highlight any errors during build
-	"rust_syntax_checking": true
+	"rust_syntax_checking": true,
+
+    // If your cargo project has several build targets, it's possible to specify mapping of 
+    // source code filenames to the target names to enable syntax checking.
+    // "projects": {
+    //     // One entry per project. Key is a project name.
+    //     "my_cool_stuff": {
+    //         "root": "/path/to/my/cool/stuff/project",  // without trailing /src
+    //         // Targets will be used to replace {target} part in the syntax check command: 
+    //         // command = 'cargo rustc {target} -- <some options>'. If no one target matches
+    //         // an empty string will be used.
+    //         "targets": {
+    //             "bin/foo.rs": "--bin foo",  // format is "source_code_filename -> target_name"
+    //             "bin/bar.rs": "--bin bar",
+    //             "_default": "--lib"         // or "--bin main"
+    //         }
+    //     }
+    // }
 }


### PR DESCRIPTION
Current implementation of syntax checking silently fails on cargo projects with several build targets (when there is `src/main.rs` and `src/lib.rs` at the same time or `src/bin/foo.rs`, `src/bin/bar.rs` and `src/lib.rs`). 

I've added customization support for `cargo rustc -- {target} -Zno-trans -Zunstable-options --error-format=json` command. One can affect on the `{target}` part via tweaking per-projects settings. 

Also since now the plugin writes explicit error message when `cargo rustc` command ends up with error.