### PR TITLE
Compare only canonical path names

### DIFF
--- a/plugin.py
+++ b/plugin.py
@@ -38,9 +38,9 @@ class rustPluginSyntaxCheckEvent(sublime_plugin.EventListener):
             # Warning color
             base_color = "#FF0"
 
-        view_filename = view.file_name()
+        view_filename = os.path.realpath(view.file_name())
         for span in info['spans']:
-            if not view_filename.endswith(span['file_name']):
+            if view_filename != os.path.realpath(span['file_name']):
                 continue
             color = base_color
             char = "^"


### PR DESCRIPTION
Fixes #95 (maybe?)

This seems to work well enough for me, but I don't have enough knowledge of filename handling by Rust/Cargo on all platforms to confirm this works 100% of the time.