### PR TITLE
changing cmd to shell_cmd so that the environment's path is used fixes #92

### DIFF
--- a/Rust.sublime-build
+++ b/Rust.sublime-build
@@ -1,16 +1,16 @@
 {
-    "cmd": ["rustc", "$file"],
+    "shell_cmd": "rustc $file",
     "selector": "source.rust",
     "file_regex": "  --> ([^:]+):([0-9]+):([0-9]+)$",
     "osx":
     {
-        "path": "/usr/bin:/bin:/usr/sbin:/sbin:/usr/local/bin"
+        "path": "~/.cargo/bin:$path",
     },
 
     "variants": [
         {
             "selector": "source.rust",
-            "cmd": ["./$file_base_name"],
+            "shell_cmd": "./$file_base_name",
             "name": "Run",
             "windows":
             {


### PR DESCRIPTION
After the conversation in https://github.com/rust-lang/sublime-rust/issues/92 and with FichteFoll.
I've changed the cmd to shell_cmd.

```cmd``` doesn't use the outer environment path, which means having sublime pick up rust from within ~/.cargo/bin is not possible. However, shell_cmd will pick up the system path form the shell.

FichteFoll figured out in https://github.com/SublimeTextIssues/Core/issues/1039 that when you use shell_cmd you can modify the $path variable and manipulate the path before the command fires.
@FichteFoll what you think of this?

After this fix Sublime now picks up the rustc executable in ~/.cargo/bin
In theory this shouldn't break anyone's sublime but it would be nice to have people try this fix and tell me if it still picks up their Rust.
@brson @thinkofname @jacius