### PR TITLE
change cargo to shell_cmd so it uses the correct system path

### DIFF
--- a/Cargo.sublime-build
+++ b/Cargo.sublime-build
@@ -1,24 +1,28 @@
 {
-    "cmd": ["cargo", "build"],
+    "shell_cmd": "cargo build",
     "selector": "source.rust",
     "file_regex": "[ \\t]*-->[ \\t]*(.*?):([0-9]+):([0-9]+)$",
     "syntax": "Cargo.build-language",
+    "osx":
+    {
+        "path": "~/.cargo/bin:$path",
+    },
 
     "variants": [
         {
-            "cmd": ["cargo", "run"],
+            "shell_cmd": "cargo run",
             "name": "Run"
         },
         {
-            "cmd": ["cargo", "test"],
+            "shell_cmd": "cargo test",
             "name": "Test"
         },
         {
-            "cmd": ["cargo", "bench"],
+            "shell_cmd": "cargo bench",
             "name": "Bench"
         },
         {
-            "cmd": ["cargo", "clean"],
+            "shell_cmd": "cargo clean",
             "name": "Clean"
         }
     ]


### PR DESCRIPTION
using Cargo from rustup currently doesn't work, this will (hopefully) solve that issue