### PR TITLE
Corrects the package name from Rust Enhanced to Rust

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ http://wbond.net/sublime_packages/package_control/installation for
 instructions.
 
 Open the palette (`control+shift+P` or `command+shift+P`) in Sublime Text
-and select `Package Control: Install Package` and then select `Rust Enhanced` from
+and select `Package Control: Install Package` and then select `Rust` from
 the list. That's it.  
 
 ## Features


### PR DESCRIPTION
The name under Package Control is not `Rust Enhanced` it is `Rust`. I was confused for a while thinking that I needed to update Sublime or something.

[See here on Package Control.](https://packagecontrol.io/packages/Rust)