### PR TITLE
BUGFIX/URGENT With trailing comma, Sublime won't open

### DIFF
--- a/Rust.sublime-settings
+++ b/Rust.sublime-settings
@@ -1,6 +1,6 @@
 {
     // Enable the syntax checking plugin, which will highlight any errors during build
-    "rust_syntax_checking": true,
+    "rust_syntax_checking": true
 
     // If your cargo project has several build targets, it's possible to specify mapping of
     // source code filenames to the target names to enable syntax checking.


### PR DESCRIPTION
I've removed the trailing comma of `Rust.sublime-settings`. With it, Sublime won't behave correctly and won't open unless you delete the `Rust` package or fix this and kill the current Sublime process. When you already have open files, you'll get the following fatal error message: 

![image](https://cloud.githubusercontent.com/assets/7553006/19453098/90d1152e-9492-11e6-905b-e8cc0d87981b.png)

It is a parsing error. The cause is a [recent commit](https://github.com/rust-lang/sublime-rust/commit/8cdb525a3d422c4cf7a25810d1378d8312b416ee#diff-b2ae26b8af80d148c02f53c14a482fc4R3).
This bug makes Sublime completely useless if you close all the files and try to reopen