### PR TITLE
Fix cargo error regex

### DIFF
--- a/Cargo.sublime-build
+++ b/Cargo.sublime-build
@@ -1,7 +1,7 @@
 {
     "shell_cmd": "cargo build",
     "selector": "source.rust",
-    "file_regex": "(?|(^[^<].*?):([0-9]+):([0-9]+):\\s[0-9]+:[0-9]+\\s(.*)$|([[a-zA-Z]+\\.[A-Za-z]{2}):([0-9]+)$)",
+    "file_regex": "[ \\t]*-->[ \\t]*([^<]*?):([0-9]+):([0-9]+)",
     "syntax": "Cargo.build-language",
     "osx":
     {

--- a/Cargo.sublime-build
+++ b/Cargo.sublime-build
@@ -1,7 +1,7 @@
 {
     "shell_cmd": "cargo build",
     "selector": "source.rust",
-    "file_regex": "[ \\t]*-->[ \\t]*([^<]*?):([0-9]+):([0-9]+)",
+    "file_regex": "(?|, ([^,<\n]*\\.[A-z]{2}):([0-9]+)|[ \t]*-->[ \t]*([^<\n]*):([0-9]+):([0-9]+))",
     "syntax": "Cargo.build-language",
     "osx":
     {


### PR DESCRIPTION
https://github.com/rust-lang/sublime-rust/commit/094ad9ae7548d2caca7725d4c3283c4df8f8e74d seems to reverted it to the old format but all they wanted was to ignore files containing '<'