### PR TITLE
Syntax changes with aim of improving consitency

### DIFF
--- a/Rust.sublime-syntax
+++ b/Rust.sublime-syntax
@@ -71,6 +71,11 @@ contexts:
         1: storage.modifier.rust
         2: storage.type.type.rust
         3: entity.name.type.rust
+      push:
+        - meta_scope: meta.type.type.rust
+        - include: type-any-identifier
+        - match: ';'
+          pop: true
 
     - match: '\b(?:(pub)\s+)?(trait)\s+({{identifier}})\b'
       captures:
@@ -403,7 +408,7 @@ contexts:
       scope: storage.modifier.rust
     - match: \b(fn)\b(\()
       captures:
-        1: keyword.other.rust
+        1: keyword.function.rust
         2: meta.group.rust punctuation.definition.group.begin.rust
       push:
         - meta_content_scope: meta.group.rust

--- a/Rust.sublime-syntax
+++ b/Rust.sublime-syntax
@@ -76,7 +76,7 @@ contexts:
       captures:
         1: storage.modifier.rust
         2: storage.type.trait.rust
-        3: entity.name.trait.rust
+        3: entity.name.type.trait.rust
       push:
         - meta_scope: meta.trait.rust
         - include: statements-block

--- a/Rust.sublime-syntax
+++ b/Rust.sublime-syntax
@@ -544,6 +544,21 @@ contexts:
               push: enum-unnamed
             - match: '(?=\{)'
               push: enum-named
+            - match: '(?==)'
+              push: enum-number
+
+  enum-number:
+    - include: comments
+    - match: '(?=[,\}])'
+      pop: true
+    - match: '='
+      scope: keyword.operator.rust
+      push:
+        - meta_scope: meta.group.rust
+        - include: comments
+        - match: '(?=[,\}])'
+          pop: true
+        - include: statements
 
   enum-unnamed:
     - include: comments

--- a/Rust.sublime-syntax
+++ b/Rust.sublime-syntax
@@ -396,7 +396,7 @@ contexts:
     - include: type-any-identifier
     - match: ':'
       scope: punctuation.separator.rust
-    - match: '\+'
+    - match: '\+|='
       scope: keyword.operator.rust
 
   type-any-identifier:
@@ -421,6 +421,8 @@ contexts:
       scope: storage.modifier.lifetime.rust
     - match: '\b({{identifier}})\b::'
       scope: meta.path.rust
+    - match: '\b({{identifier}})\b'
+      scope: storage.type.rust
     - match: '(?=<)'
       push: generic-angles
     - match: '\('
@@ -733,7 +735,7 @@ contexts:
           scope: storage.modifier.lifetime.rust
         - match: '(?=\S)'
           pop: true
-    - include: basic-identifiers
+    - include: type-any-identifier
     - match: ':'
       scope: punctuation.separator.rust
 
@@ -811,7 +813,7 @@ contexts:
           scope: storage.modifier.lifetime.rust
         - match: '(?=\S)'
           pop: true
-    - include: basic-identifiers
+    - include: type-any-identifier
     - match: ':'
       scope: punctuation.separator.rust
     - match: ';'
@@ -1035,6 +1037,8 @@ contexts:
     - match: '\b(c_[[:lower:][:digit:]_]+|[[:lower:]_][[:lower:][:digit:]_]*_t)\b'
       scope: storage.type.rust
     - match: '\b_*[A-Z][a-zA-Z0-9_]*[a-z][a-zA-Z0-9_]*\b'
+      scope: storage.type.source.rust
+    - match: '\b{{int_suffixes}}*\b'
       scope: storage.type.source.rust
     - match: '(?={{identifier}}::)'
       push:

--- a/Rust.sublime-syntax
+++ b/Rust.sublime-syntax
@@ -150,9 +150,6 @@ contexts:
     - include: strings
     - include: chars
 
-    - match: '\b[[:lower:]_][[:lower:][:digit:]_]*(?=\()'
-      scope: support.function.rust
-
     - match: '\b((?:format|print|println)!)\s*(\()'
       captures:
         1: support.macro.rust

--- a/Rust.sublime-syntax
+++ b/Rust.sublime-syntax
@@ -704,7 +704,7 @@ contexts:
     - match: '(?=\bwhere\b)'
       set: impl-where
     - match: '{{identifier}}'
-      scope: entity.name.impl.rust
+      scope: entity.name.type.impl.rust
     - match: '(?=<)'
       push: generic-angles
     - match: '&'

--- a/Rust.sublime-syntax
+++ b/Rust.sublime-syntax
@@ -228,7 +228,7 @@ contexts:
       scope: punctuation.separator.rust
       push: after-operator
 
-    - match: '\.\.\.|\.\.||[-=<>&|!~@?+*/%^''#$]|\b_\b'
+    - match: '\.\.\.|\.\.|\.||[-=<>&|!~@?+*/%^''#$]|\b_\b'
       scope: keyword.operator.rust
 
   block:

--- a/Rust.sublime-syntax
+++ b/Rust.sublime-syntax
@@ -277,6 +277,7 @@ contexts:
     - include: try-closure
 
   try-closure:
+    - include: comments
     - match: '\s*(?=\|)'
       set: closure
     # Exit the context if we didn't find a closure
@@ -310,20 +311,24 @@ contexts:
     # scope as soon as we hit something that it not a
     # valid part so the whole rest of the document isn't
     # highlighted using the params scope
-    - match: '(?=[};)\]\n])'
+    - include: comments
+    - match: '(?=[};)\]]|\blet\b)'
       pop: true
     - match: '\|'
       scope: punctuation.definition.parameters.end.rust
       pop: true
     - match: \bself\b
       scope: variable.parameter.rust
-    - match: '({{identifier}})\s*(?:(:(?!:))|(?=\||,))'
+    - match: '({{identifier}})\s*(:(?!:))?'
       captures:
         1: variable.parameter.rust
         2: punctuation.separator.rust
       push:
+        - include: comments
         - match: (?=,|\|)
           pop: true
+        - match: ':(?!:)'
+          scope: punctuation.separator.rust
         - include: type-any-identifier
     - match: '&'
       scope: keyword.operator.rust

--- a/Rust.sublime-syntax
+++ b/Rust.sublime-syntax
@@ -85,14 +85,12 @@ contexts:
       scope: keyword.impl.rust
       push: impl-definition
 
-    - match: '\b(?:(pub)\s+)?(enum)\s+({{identifier}})\b'
+    - match: '\b(?:(pub)\s+)?(enum)\s+'
+      scope: meta.enum.rust
       captures:
         1: storage.modifier.rust
         2: storage.type.enum.rust
-        3: entity.name.enum.rust
-      push:
-        - meta_scope: meta.enum.rust
-        - include: statements-block
+      set: enum-identifier
 
     - match: \b(let|const|static)\b
       scope: storage.type.rust keyword.other.rust
@@ -421,13 +419,7 @@ contexts:
         - include: type-any-identifier
     - match: '''{{identifier}}(?!\'')\b'
       scope: storage.modifier.lifetime.rust
-    - match: '\b([[:upper:]]|_*[[:upper:]][[:alnum:]_]*[[:lower:]][[:alnum:]_]*)\b::'
-      scope: meta.path.rust storage.type.rust
-      captures:
-        1: storage.type.rust
-    - match: '{{identifier}}::'
-      scope: meta.path.rust
-    - match: '::(?={{identifier}})'
+    - match: '\b({{identifier}})\b::'
       scope: meta.path.rust
     - match: '(?=<)'
       push: generic-angles
@@ -496,6 +488,85 @@ contexts:
         - include: comments
         - match: \bpub\b
           scope: storage.modifier.rust
+        - match: '{{identifier}}(?=\s*:)'
+          scope: variable.other.member.rust
+          push:
+            - match: ',|(?=\})'
+              pop: true
+            - include: comments
+            - match: ':'
+              scope: punctuation.separator.rust
+            - include: type-any-identifier
+
+  enum-identifier:
+    - meta_scope: meta.enum.rust
+    - match: '{{identifier}}(?=<)'
+      scope: entity.name.type.enum.rust
+      set:
+        - meta_scope: meta.enum.rust meta.generic.rust
+        - match: '(?=<)'
+          push: generic-angles
+        - match: ''
+          set: enum-body
+    - match: '{{identifier}}'
+      scope: entity.name.type.enum.rust
+      set: enum-body
+
+  enum-body:
+    - meta_scope: meta.enum.rust
+    - include: comments
+    - match: '\}'
+      scope: punctuation.definition.block.end.rust
+      pop: true
+    - match: '\{'
+      scope: punctuation.definition.block.begin.rust
+      push:
+        - meta_scope: meta.block.rust
+        - include: comments 
+        - match: '(?=\})'
+          pop: true
+        - match: '{{identifier}}'
+          scope: storage.type.enum.rust
+          push:
+            - include: comments
+            - match: ',|(?=\})'
+              pop: true
+            - match: '(?=\()'
+              push: enum-unnamed
+            - match: '(?=\{)'
+              push: enum-named
+
+  enum-unnamed:
+    - include: comments
+    - match: '\)'
+      scope: punctuation.definition.group.end.rust
+      pop: true
+    - match: '\('
+      scope: punctuation.definition.group.begin.rust
+      # Ensure that we end the unnamed at the next ) to
+      # prevent odd highlighting as the user is typing
+      with_prototype:
+        - match: '(?=\))'
+          pop: true
+      push:
+        - meta_scope: meta.group.rust
+        - include: comments
+        - include: type-any-identifier
+
+  enum-named:
+    - include: comments
+    - match: '\}'
+      scope: punctuation.definition.block.end.rust
+      pop: true
+    - match: '\{'
+      scope: punctuation.definition.block.begin.rust
+      push:
+        - meta_scope: meta.block.rust
+        - match: '(?=\})'
+          pop: true
+        - include: comments
+        - match: \bpub\b
+          scope: invalid.illegal.rust
         - match: '{{identifier}}(?=\s*:)'
           scope: variable.other.member.rust
           push:

--- a/Rust.sublime-syntax
+++ b/Rust.sublime-syntax
@@ -27,9 +27,9 @@ contexts:
     - match: ';'
       scope: punctuation.terminator
 
-    - match: '''({{identifier}})\s*(:)'
+    - match: '(''{{identifier}})\s*(:)'
       captures:
-        1: entity.name.label.rust
+        1: entity.name.support.label.rust
         2: punctuation.separator.rust
 
     - match: '''{{identifier}}(?!\'')\b'

--- a/Rust.sublime-syntax
+++ b/Rust.sublime-syntax
@@ -444,7 +444,7 @@ contexts:
 
   struct-identifier:
     - match: '{{identifier}}(?=<)'
-      scope: entity.name.struct.rust
+      scope: entity.name.type.struct.rust
       set:
         - meta_scope: meta.struct.rust meta.generic.rust
         - match: '(?=<)'
@@ -452,7 +452,7 @@ contexts:
         - match: ''
           set: struct-body
     - match: '{{identifier}}'
-      scope: entity.name.struct.rust
+      scope: entity.name.type.struct.rust
       set: struct-body
 
   struct-body:

--- a/Rust.sublime-syntax
+++ b/Rust.sublime-syntax
@@ -359,6 +359,7 @@ contexts:
 
   type:
     - match: '{{identifier}}(?=<)'
+      scope: storage.type.rust
       push: generic-angles
     - match: \b(Self|i8|i16|i32|i64|isize|u8|u16|u32|u64|usize|f32|f64|bool|char|str)\b
       scope: storage.type.rust

--- a/Rust.sublime-syntax
+++ b/Rust.sublime-syntax
@@ -56,7 +56,7 @@ contexts:
       scope: meta.function.rust
       captures:
         1: storage.modifier.rust
-        2: storage.type.function.rust
+        2: keyword.function.rust
       push: fn-definition
 
     - match: '\b(?:(pub)\s+)?(struct)\s+'
@@ -82,7 +82,7 @@ contexts:
         - include: statements-block
 
     - match: '\bimpl\b'
-      scope: storage.type.impl.rust
+      scope: keyword.impl.rust
       push: impl-definition
 
     - match: '\b(?:(pub)\s+)?(enum)\s+({{identifier}})\b'
@@ -98,7 +98,7 @@ contexts:
       scope: storage.type.rust keyword.other.rust
 
     - match: \bfn\b
-      scope: storage.type.function.rust
+      scope: keyword.function.rust
 
     - match: \bmod\b
       scope: storage.type.module.rust
@@ -107,7 +107,7 @@ contexts:
       scope: storage.type.struct.rust
 
     - match: \bimpl\b
-      scope: storage.type.impl.rust
+      scope: keyword.impl.rust
 
     - match: \benum\b
       scope: storage.type.enum.rust
@@ -408,7 +408,7 @@ contexts:
       scope: storage.modifier.rust
     - match: \b(fn)\b(\()
       captures:
-        1: storage.type.function.rust
+        1: keyword.other.rust
         2: meta.group.rust punctuation.definition.group.begin.rust
       push:
         - meta_content_scope: meta.group.rust

--- a/Rust.sublime-syntax
+++ b/Rust.sublime-syntax
@@ -525,7 +525,6 @@ contexts:
         - match: '(?=\})'
           pop: true
         - match: '{{identifier}}'
-          scope: storage.type.enum.rust
           push:
             - include: comments
             - match: ',|(?=\})'

--- a/Rust.sublime-syntax
+++ b/Rust.sublime-syntax
@@ -39,7 +39,7 @@ contexts:
       captures:
         1: storage.modifier.rust
         2: storage.type.module.rust
-        3: entity.name.module.rust
+        3: entity.name.type.module.rust
       push:
         - meta_scope: meta.module.rust
         - match: ';'

--- a/syntax_test_rust.rs
+++ b/syntax_test_rust.rs
@@ -205,7 +205,7 @@ struct PrintableStruct(Box<i32>);
 //^^^^ storage.type.struct
 //     ^^^^^^^^^^^^^^^ entity.name.type.struct
 //                    ^ punctuation.definition.group.begin
-//                     ^^^^^^^^ meta.generic
+//                     ^^^^^^^^ meta.struct.rust
 //                        ^ punctuation.definition.generic.begin
 //                         ^^^ storage.type
 //                            ^ punctuation.definition.generic.end
@@ -733,8 +733,10 @@ fn collect_vec() {
 //                     ^^^^^ storage.type
 //                          ^ punctuation.definition.type.end
 //                                                            ^^^^^^^^ meta.generic
-//                                                             ^^^^^^ meta.generic meta.generic
+//                                                             ^^^ storage.type
+//                                                                ^ punctuation.definition.generic.begin
 //                                                                 ^ keyword.operator
+//                                                                  ^ punctuation.definition.generic.begin
     let _: Vec<(usize, usize)> = vec!();
 //                               ^^^^ support.macro
     let _: Vec<(usize, usize)> = vec!{};
@@ -918,6 +920,7 @@ impl<T> Iterator for Fibonacci<T>
 //         ^ punctuation.definition.generic.end.rust
 //           ^ keyword.operator.rust
 //            ^^ storage.modifier.lifetime.rust
+//                             ^ keyword.operator.rust
 {
     unimplemented!();
 }

--- a/syntax_test_rust.rs
+++ b/syntax_test_rust.rs
@@ -921,7 +921,48 @@ impl<T> Iterator for Fibonacci<T>
 //            ^^ storage.modifier.lifetime.rust
 //                             ^ keyword.operator.rust
 {
-    unimplemented!();
+    let fibby = |
+//      ^^^^^ entity.name.function
+//            ^ keyword.operator
+//              ^ punctuation.definition.parameters.begin
+        n: i32
+//      ^ variable.parameter
+//       ^ punctuation.separator
+//         ^^^ storage.type
+    | { unimplemented!() };
+//  ^ punctuation.definition.parameters.end
+    let fibby = |n| { unimplemented!() };
+//      ^^^^^ entity.name.function
+//              ^ punctuation.definition.parameters.begin
+//               ^ variable.parameter
+//                ^ punctuation.definition.parameters.end
+    let fibby = |n: i32| { unimplemented!() };
+//              ^ punctuation.definition.parameters.begin
+//               ^ variable.parameter
+//                ^ punctuation.separator
+//                     ^ punctuation.definition.parameters.end
+    let fibby = |n:i32| { unimplemented!() };
+//              ^ punctuation.definition.parameters.begin
+//               ^ variable.parameter
+//                ^ punctuation.separator
+//                 ^^^ storage.type
+//                    ^ punctuation.definition.parameters.end
+    let fibby = |n /**/| { unimplemented!() };
+//              ^ punctuation.definition.parameters.begin
+//               ^ variable.parameter
+//                 ^^^^ comment.block
+//                     ^ punctuation.definition.parameters.end
+    let fibby = |n /**/ : /**/ std::result::Result /**/| { unimplemented!() };
+//              ^ punctuation.definition.parameters.begin
+//               ^ variable.parameter
+//                 ^^^^ comment.block
+//                      ^ punctuation.separator
+//                        ^^^^ comment.block
+//                             ^^^^^^^^^^^^^ meta.path
+//                                          ^^^^^^ storage.type
+//                                                 ^^^^ comment.block
+//                                                     ^ punctuation.definition.parameters.end
+    unimplemented!();    
 }
 
 pub const FOO: Option<[i32; 1]> = Some([1]);

--- a/syntax_test_rust.rs
+++ b/syntax_test_rust.rs
@@ -716,6 +716,7 @@ impl<'a, T: MyTrait + OtherTrait> PrintInOption for T where
 pub trait Animal {
 // <- storage.modifier
 //^^^^^^^^^^^^^^^^ meta.trait
+//        ^^^^^^ entity.name.type.trait.rust
 //               ^ meta.block punctuation.definition.block.begin
     fn noise(quiet: bool) {
         // Comment

--- a/syntax_test_rust.rs
+++ b/syntax_test_rust.rs
@@ -218,7 +218,7 @@ impl fmt::Display for PrintableStruct {
 //^^ keyword.impl.rust
 //   ^^^^^ meta.path
 //                ^^^ keyword.other
-//                    ^^^^^^^^^^^^^^^ entity.name.impl
+//                    ^^^^^^^^^^^^^^^ entity.name.type.impl
 //                                    ^ meta.block punctuation.definition.block.begin
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
 // ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ meta.impl
@@ -678,8 +678,8 @@ impl <'a, T> GenVal<T> {
 //   ^ punctuation.definition.generic.begin
 //    ^^ storage.modifier.lifetime
 //         ^ punctuation.definition.generic.end
-//           ^^^^^^ entity.name.impl
-//                 ^^^ - entity.name.impl
+//           ^^^^^^ entity.name.type.impl
+//                 ^^^ - entity.name.type.impl
 //                 ^ punctuation.definition.generic.begin
 //                   ^ punctuation.definition.generic.end
     fn value(&self) -> &T { &self.0 }
@@ -704,7 +704,7 @@ impl<'a, T: MyTrait + OtherTrait> PrintInOption for T where
 //        ^ punctuation.separator
 //                  ^ keyword.operator
 //                                              ^^^ keyword.other
-//                                                  ^ entity.name.impl
+//                                                  ^ entity.name.type.impl
 //                                                    ^^^^^ keyword.other
     Option<T>: Debug {
 //^^^^^^^^^^^^^^^^^^^^ meta.impl

--- a/syntax_test_rust.rs
+++ b/syntax_test_rust.rs
@@ -332,11 +332,20 @@ enum OperatingSystem
     Bsd(String),
 //     ^ punctuation.definition.group.begin.rust
 //            ^ punctuation.definition.group.end.rust
-    Info { field: i32, value: str }
+    Info { field: i32, value: str },
 //       ^ meta.enum meta.block punctuation.definition.block.begin
 //                ^^^ storage.type
 //                            ^^^ storage.type
 //                                ^ meta.enum meta.block punctuation.definition.block.end
+    One = 0x01,
+//  ^^^ meta.enum
+//      ^ meta.enum keyword.operator
+//        ^^^^ meta.enum constant.numeric.integer
+//            ^ meta.enum meta.block
+    Two = 0x02
+//  ^^^ meta.enum
+//      ^ meta.enum keyword.operator
+//        ^^^^ meta.enum constant.numeric.integer
 }
 // <- meta.enum punctuation.definition.block.end
 
@@ -971,8 +980,6 @@ pub const FOO: Option<[i32; 1]> = Some([1]);
 //                    ^ punctuation.definition.group.begin.rust
 //                           ^ punctuation.definition.group.end.rust
 //                            ^ punctuation.definition.generic.end.rust
-
-let n = a<b;
 
 pub struct Channel<T:Service> {
     pub rx: Receiver<T::In::Blah>,

--- a/syntax_test_rust.rs
+++ b/syntax_test_rust.rs
@@ -523,7 +523,7 @@ match n {
 // Binding
 match my_func() {
 // ^^ keyword.control
-//    ^^^^^^^ support.function
+//    ^^^^^^^ source.rust
 //              ^ meta.block punctuation.definition.block.begin
     0 => println!("None"),
 //  ^ constant.numeric.integer.decimal

--- a/syntax_test_rust.rs
+++ b/syntax_test_rust.rs
@@ -413,7 +413,7 @@ let big_n =
 //  ^ meta.block punctuation.definition.block.end
 
 'label_name: loop {
-// ^^^^^^^^ entity.name.label
+// ^^^^^^^^ entity.name.support.label
 //         ^ punctuation.separator
 //           ^^^^ keyword.control
 //                ^ meta.block punctuation.definition.block.begin

--- a/syntax_test_rust.rs
+++ b/syntax_test_rust.rs
@@ -214,8 +214,8 @@ struct PrintableStruct(Box<i32>);
 impl fmt::Display for PrintableStruct {
 // <- meta.impl
 //^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ meta.impl
-// <- storage.type.impl
-//^^ storage.type.impl
+// <- keyword.impl.rust
+//^^ keyword.impl.rust
 //   ^^^^^ meta.path
 //                ^^^ keyword.other
 //                    ^^^^^^^^^^^^^^^ entity.name.impl
@@ -223,7 +223,7 @@ impl fmt::Display for PrintableStruct {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
 // ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ meta.impl
 //  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ meta.function
-//  ^^ storage.type.function
+//  ^^ keyword.function.rust
 //     ^^^ entity.name.function
 //        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ meta.function.parameters
 //        ^ punctuation.definition.parameters.begin
@@ -287,7 +287,7 @@ let xsl = &xs;
 
 type FnPointer = fn(i32) -> i32;
 //   ^^^^^^^^^ entity.name.type
-//               ^^ storage.type.function
+//               ^^ keyword.function.rust
 //                 ^^^^^ meta.group
 //                  ^^^ storage.type
 //                       ^^ punctuation.separator
@@ -296,7 +296,7 @@ type FnPointer = fn(i32) -> i32;
 type GenFnPointer = Bar<fn(i32) -> i32>;
 //   ^^^^^^^^^^^^ entity.name.type
 //                  ^^^^^^^^^^^^^^^^^^^ meta.generic
-//                      ^^ storage.type.function
+//                      ^^ keyword.other.rust
 //                        ^^^^^ meta.group
 //                         ^^^ storage.type
 //                              ^^ punctuation.separator
@@ -308,7 +308,7 @@ type GenFnPointer2 = Bar<extern "C" fn()>;
 //                   ^^^^^^^^^^^^^^^^^^^^ meta.generic
 //                       ^^^^^^ keyword.other
 //                              ^^^ string.quoted.double
-//                                  ^^ storage.type.function
+//                                  ^^ keyword.other.rust
 //                                       ^ - meta.generic
 
 struct Nil;
@@ -365,7 +365,7 @@ let z = {
 // <- meta.block punctuation.definition.block.end
 
 fn my_func(x: i32)
-// <- storage.type.function
+// <- keyword.function.rust
 // ^^^^^^^ entity.name.function
 //        ^^^^^^^^ meta.function.parameters
 //        ^ punctuation.definition.parameters.begin
@@ -492,7 +492,7 @@ while let BasicStruct(k) = j {
 // <- meta.block punctuation.definition.block.end
 
 fn foo<A>(i: u32, b: i64) -> u32 {
-// <- storage.type.function
+// <- keyword.function.rust
 // ^^^ entity.name.function
 //    ^ punctuation.definition.generic.begin
 //      ^ punctuation.definition.generic.end
@@ -564,7 +564,7 @@ impl Point
 {
 // <- meta.impl meta.block punctuation.definition.block.begin
     fn new(x: i32, y: i32) -> Point
-    // <- storage.type.function
+    // <- keyword.function.rust
     // ^^^ entity.name.function
     {
     // <- meta.function meta.block
@@ -580,7 +580,7 @@ impl Point
 
 pub fn pub_function() -> bool
 // <- storage.modifier
-//  ^^ storage.type.function
+//  ^^ keyword.function.rust
 //     ^^^^^^^^^^^^ entity.name.function
 {
 // <- meta.function
@@ -755,7 +755,7 @@ macro_rules! forward_ref_binop [
 //                                                    ^^ keyword.operator
 //                                                       ^ meta.macro meta.group meta.block punctuation.definition.block.begin
         impl<'a, 'b> $imp<&'a $u> for &'b $t {
-//      ^^^^ storage.type.impl
+//      ^^^^ keyword.impl.rust
 //          ^^^^^^^^ meta.generic
 //           ^^ storage.modifier.lifetime
 //               ^^ storage.modifier.lifetime
@@ -776,7 +776,7 @@ macro_rules! forward_ref_binop [
             #[inline]
 //          ^^^^^^^^^ comment.block.attribute
             fn $method(self, other: &'a $u) -> <$t as $imp<$u>>::Output {
-//          ^^ storage.type.function
+//          ^^ keyword.function.rust
 //             ^^^^^^^ variable.other
 //                     ^^^^ variable.language
 //                                  ^ keyword.operator

--- a/syntax_test_rust.rs
+++ b/syntax_test_rust.rs
@@ -287,7 +287,7 @@ let xsl = &xs;
 
 type FnPointer = fn(i32) -> i32;
 //   ^^^^^^^^^ entity.name.type
-//               ^^ keyword.function.rust
+//               ^^ keyword.function
 //                 ^^^^^ meta.group
 //                  ^^^ storage.type
 //                       ^^ punctuation.separator
@@ -295,8 +295,8 @@ type FnPointer = fn(i32) -> i32;
 
 type GenFnPointer = Bar<fn(i32) -> i32>;
 //   ^^^^^^^^^^^^ entity.name.type
-//                  ^^^^^^^^^^^^^^^^^^^ meta.generic
-//                      ^^ keyword.other.rust
+//                  ^^^ storage.type
+//                      ^^ keyword.function
 //                        ^^^^^ meta.group
 //                         ^^^ storage.type
 //                              ^^ punctuation.separator
@@ -305,10 +305,10 @@ type GenFnPointer = Bar<fn(i32) -> i32>;
 
 type GenFnPointer2 = Bar<extern "C" fn()>;
 //   ^^^^^^^^^^^^^ entity.name.type
-//                   ^^^^^^^^^^^^^^^^^^^^ meta.generic
+//                   ^^^ storage.type
 //                       ^^^^^^ keyword.other
 //                              ^^^ string.quoted.double
-//                                  ^^ keyword.other.rust
+//                                  ^^ keyword.function
 //                                       ^ - meta.generic
 
 struct Nil;
@@ -774,8 +774,7 @@ macro_rules! forward_ref_binop [
 //                                        ^^ variable.other
 //                                           ^ meta.macro meta.group meta.block meta.impl meta.block punctuation.definition.block.begin
             type Output = <$t as $imp<$u>>::Output;
-//                        ^^^^^^^^^^^^^^^^ meta.generic
-//                                        ^^ meta.path
+//                        ^^^^^^^^^^^^^^^^^^^^^^^^ meta.type.type.rust
 
             #[inline]
 //          ^^^^^^^^^ comment.block.attribute

--- a/syntax_test_rust.rs
+++ b/syntax_test_rust.rs
@@ -212,8 +212,8 @@ struct PrintableStruct(Box<i32>);
 //                             ^ punctuation.definition.group.end
 
 impl fmt::Display for PrintableStruct {
-// <- meta.impl
-//^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ meta.impl
+// <- meta.impl.rust
+//^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ meta.impl.rust
 // <- keyword.impl.rust
 //^^ keyword.impl.rust
 //   ^^^^^ meta.path
@@ -323,21 +323,22 @@ struct Pair(i32, i32);
 enum OperatingSystem
 // <- storage.type.enum
 // ^^^^^^^^^^^^^^^^^ meta.enum
-//   ^^^^^^^^^^^^^^^ entity.name.enum
+//   ^^^^^^^^^^^^^^^ entity.name.type.enum
 {
 // <- meta.enum meta.block punctuation.definition.block.begin
     Osx,
     Windows,
     Linux,
     Bsd(String),
-    //  ^^^^^^ support.type
+//     ^ punctuation.definition.group.begin.rust
+//            ^ punctuation.definition.group.end.rust
     Info { field: i32, value: str }
-    //   ^ meta.block meta.block punctuation.definition.block.begin
-    //            ^^^ storage.type
-    //                        ^^^ storage.type
-    //                            ^ meta.block meta.block punctuation.definition.block.end
+//       ^ meta.enum meta.block punctuation.definition.block.begin
+//                ^^^ storage.type
+//                            ^^^ storage.type
+//                                ^ meta.enum meta.block punctuation.definition.block.end
 }
-// <- meta.enum meta.block punctuation.definition.block.end
+// <- meta.enum punctuation.definition.block.end
 
 const ZERO: u64 = 0;
 // <- storage.type
@@ -924,3 +925,8 @@ impl<T> Iterator for Fibonacci<T>
 pub const FOO: Option<[i32; 1]> = Some([1]);
 //                    ^ punctuation.definition.group.begin.rust
 //                           ^ punctuation.definition.group.end.rust
+
+pub struct Channel<T:Service> {
+    pub rx: Receiver<T::In::Blah>,
+    pub tx: Receiver<T::Out::Blah>,
+}

--- a/syntax_test_rust.rs
+++ b/syntax_test_rust.rs
@@ -191,7 +191,7 @@ struct BasicStruct(i32);
 // ^^^^^^^^^^^^^^^^^^^^ meta.struct
 // <- storage.type.struct
 //^^^^ storage.type.struct
-//     ^^^^^^^^^^^ entity.name.struct
+//     ^^^^^^^^^^^ entity.name.type.struct
 //                ^ punctuation.definition.group.begin
 //                 ^^^ storage.type
 //                    ^ punctuation.definition.group.end
@@ -203,7 +203,7 @@ struct PrintableStruct(Box<i32>);
 // ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ meta.struct
 // <- storage.type.struct
 //^^^^ storage.type.struct
-//     ^^^^^^^^^^^^^^^ entity.name.struct
+//     ^^^^^^^^^^^^^^^ entity.name.type.struct
 //                    ^ punctuation.definition.group.begin
 //                     ^^^^^^^^ meta.generic
 //                        ^ punctuation.definition.generic.begin
@@ -661,8 +661,8 @@ pub mod my_mod {
 struct Val (f64,);
 struct GenVal<T>(T,);
 //     ^^^^^^^^^ meta.generic
-//     ^^^^^^ entity.name.struct
-//           ^ punctuation.definition.generic.begin - entity.name.struct
+//     ^^^^^^ entity.name.type.struct
+//           ^ punctuation.definition.generic.begin - entity.name.type.struct
 //             ^ punctuation.definition.generic.end
 
 // impl of Val

--- a/syntax_test_rust.rs
+++ b/syntax_test_rust.rs
@@ -966,8 +966,13 @@ impl<T> Iterator for Fibonacci<T>
 }
 
 pub const FOO: Option<[i32; 1]> = Some([1]);
+//             ^^^^^^ storage.type
+//                   ^ punctuation.definition.generic.begin.rust
 //                    ^ punctuation.definition.group.begin.rust
 //                           ^ punctuation.definition.group.end.rust
+//                            ^ punctuation.definition.generic.end.rust
+
+let n = a<b;
 
 pub struct Channel<T:Service> {
     pub rx: Receiver<T::In::Blah>,

--- a/syntax_test_rust.rs
+++ b/syntax_test_rust.rs
@@ -653,7 +653,7 @@ pub mod my_mod {
 //^^^^^^^^^^^^^^ meta.module
 // <- storage.modifier
 //  ^^^ storage.type.module
-//      ^^^^^^ entity.name.module
+//      ^^^^^^ entity.name.type.module.rust
 //             ^ meta.block punctuation.definition.block.begin
 }
 // <- meta.module meta.block punctuation.definition.block.end


### PR DESCRIPTION
#113 raises a good point about consitency so I've made some changes but would like some feed back. (don't merge this without discussion please)

if @boscop or @petrochenkov would like to give comment that would be appreciated

currently function calls aren't highlighted, i got stuck trying to make generic function calls match the non generic ones so gave up and went with white for all functions calls for consitency