### PR TITLE
Add a config option to include tests in the on-save syntax checking

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,10 +56,11 @@ Example:
 ### Syntax Checking
 The sublime-rust package now comes with syntax checking.
 This relies on Cargo and Rust (>= 1.8.0) being installed and on your system path. Plus Sublime Text >= 3118.
-This feature is on by default, but you can adjust the the value of ```rust_syntax_checking``` within your settings (see Settings). Additionally, the colour of the warnings and errors can be changed from the default values (seen below).
+This feature is on by default, but can be controlled for general syntax checking and for checking within tests by adjusting the values of ```rust_syntax_checking``` and ```rust_syntax_checking_include_tests``` respectively within your settings (see Settings). Additionally, the colour of the warnings and errors can be changed from the default values (seen below).
 ```json
 {
     "rust_syntax_checking": true,
+    "rust_syntax_checking_include_tests": true,
     "rust_syntax_error_color": "#F00",
     "rust_syntax_warning_color":"#FF0"
 }

--- a/RustEnhanced.sublime-settings
+++ b/RustEnhanced.sublime-settings
@@ -1,6 +1,7 @@
 {
     // Enable the syntax checking plugin, which will highlight any errors during build
     "rust_syntax_checking": true,
+    "rust_syntax_checking_include_tests": true,
     "rust_syntax_error_color": "#F00",
     "rust_syntax_warning_color":"#FF0"
 

--- a/SyntaxCheckPlugin.py
+++ b/SyntaxCheckPlugin.py
@@ -14,6 +14,7 @@ class rustPluginSyntaxCheckEvent(sublime_plugin.EventListener):
         
         settings = view.settings()
         enabled = settings.get('rust_syntax_checking')
+        enabled_for_tests = settings.get('rust_syntax_checking_include_tests') and "--test" or ""
         if enabled and "source.rust" in view.scope_name(0):
             file_name = os.path.abspath(view.file_name())
             file_dir = os.path.dirname(file_name)
@@ -21,7 +22,9 @@ class rustPluginSyntaxCheckEvent(sublime_plugin.EventListener):
             # shell=True is needed to stop the window popping up, although it looks like this is needed:
             # http://stackoverflow.com/questions/3390762/how-do-i-eliminate-windows-consoles-from-spawned-processes-in-python-2-7
             # We only care about stderr
-            cargo_command = self.cargo_rustc_command(file_name, settings)
+            cargo_command = self.cargo_rustc_command(
+                file_name, settings, enabled_for_tests=enabled_for_tests
+            )
             cargoRun = subprocess.Popen(cargo_command,
                 shell=True, stderr=subprocess.PIPE, stdout=subprocess.PIPE,
                 universal_newlines = True
@@ -48,8 +51,8 @@ class rustPluginSyntaxCheckEvent(sublime_plugin.EventListener):
             for view in view.window().views(): 
                 view.erase_phantoms('buildErrorLine')
 
-    def cargo_rustc_command(self, file_name, settings):
-        command = 'cargo rustc {target} -- -Zno-trans -Zunstable-options --error-format=json'
+    def cargo_rustc_command(self, file_name, settings, enabled_for_tests=''):
+        command = 'cargo rustc {} -- -Zno-trans -Zunstable-options {} --error-format=json'
         target = ''
         for project in settings.get('projects', {}).values(): 
             src_root = os.path.join(project.get('root', ''), 'src')
@@ -62,7 +65,7 @@ class rustPluginSyntaxCheckEvent(sublime_plugin.EventListener):
                     break
             else:
                 target = targets.get('_default', '')
-        return command.replace('{target}', target)
+        return command.format(target, enabled_for_tests)
 
 
     def add_error_phantom(self, window, info, settings):


### PR DESCRIPTION
Add an option to include tests in the on-save syntax checking handler. Without it tests are ignored e.g.:

<img width="799" alt="screen shot 2017-02-02 at 12 31 14" src="https://cloud.githubusercontent.com/assets/214628/22549579/e73e239c-e943-11e6-875d-6f7f0fd32b6e.png">

With this feature enabled, the same code is checked correctly:

<img width="774" alt="screen shot 2017-02-02 at 12 30 59" src="https://cloud.githubusercontent.com/assets/214628/22549588/f717572a-e943-11e6-8a93-2951b565e160.png">
