### PR TITLE
Add Rust symbols to global index.

### DIFF
--- a/RustSymbols.JSON-tmPreferences
+++ b/RustSymbols.JSON-tmPreferences
@@ -1,6 +1,9 @@
 {
     "name": "Rust Symbols",
-    "scope": "entity.name.function.source.rust",
-    "settings":  {"showInSymbolList": 1},
+    "scope": "entity.name.function.rust, entity.name.macro.rust, entity.name.struct.rust, entity.name.enum.rust, entity.name.module.rust, entity.name.type.rust, entity.name.trait.rust",
+    "settings": {
+        "showInSymbolList": 1,
+        "showInIndexedSymbolList": 1
+    },
     "uuid": "d3270dd1-4ccd-428e-8dda-d3d20ee9fc7e"
 }

--- a/RustSymbols.tmPreferences
+++ b/RustSymbols.tmPreferences
@@ -5,9 +5,11 @@
 	<key>name</key>
 	<string>Rust Symbols</string>
 	<key>scope</key>
-	<string>entity.name.function.source.rust</string>
+	<string>entity.name.function.rust, entity.name.macro.rust, entity.name.struct.rust, entity.name.enum.rust, entity.name.module.rust, entity.name.type.rust, entity.name.trait.rust</string>
 	<key>settings</key>
 	<dict>
+		<key>showInIndexedSymbolList</key>
+		<integer>1</integer>
 		<key>showInSymbolList</key>
 		<integer>1</integer>
 	</dict>


### PR DESCRIPTION
I'm not sure if these were left out intentionally, but I find the Goto Symbol in Project feature quite useful.