### PR TITLE
Add rust_syntax_hide_warnings option

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,8 +60,9 @@ This feature is on by default, but you can adjust the the value of ```rust_synta
 ```json
 {
     "rust_syntax_checking": true,
+    "rust_syntax_hide_warnings": false,
     "rust_syntax_error_color": "#F00",
-    "rust_syntax_warning_color":"#FF0"
+    "rust_syntax_warning_color": "#FF0"
 }
 ```
 Here is an example:

--- a/RustEnhanced.sublime-settings
+++ b/RustEnhanced.sublime-settings
@@ -1,6 +1,7 @@
 {
     // Enable the syntax checking plugin, which will highlight any errors during build
     "rust_syntax_checking": true,
+    "rust_syntax_hide_warnings": false,
     "rust_syntax_error_color": "#F00",
     "rust_syntax_warning_color":"#FF0"
 

--- a/SyntaxCheckPlugin.py
+++ b/SyntaxCheckPlugin.py
@@ -15,6 +15,7 @@ class rustPluginSyntaxCheckEvent(sublime_plugin.EventListener):
         settings = view.settings()
         enabled = settings.get('rust_syntax_checking')
         if enabled and "source.rust" in view.scope_name(0):
+            hide_warnings = settings.get('rust_syntax_hide_warnings')
             file_name = os.path.abspath(view.file_name())
             file_dir = os.path.dirname(file_name)
             os.chdir(file_dir)
@@ -40,6 +41,8 @@ class rustPluginSyntaxCheckEvent(sublime_plugin.EventListener):
                 info = json.loads(line)
                 # Can't show without spans
                 if len(info['spans']) == 0:
+                    continue
+                if info['level'] != "error" and hide_warnings:
                     continue
                 self.add_error_phantom(view.window(), info, settings)
 


### PR DESCRIPTION
This adds a `rust_syntax_hide_warnings` preference option that hides warnings. (Not that warnings aren't an excellent thing, but I personally prefer to go through a `cargo test` output and fix them at the end of a hacking session rather than seeing a ton of yellow in my editor every time it can compile.) Glad to workshop this if you folks think another way of implementing it would be better, and thanks again for the awesome project!