### PR TITLE
Add rust_syntax_hide_warnings option.

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,12 +57,14 @@ Example:
 ### Syntax Checking
 Rust Enhanced will automatically perform syntax checking each time you save a file.
 This relies on Cargo and Rust (>= 1.8.0) being installed and on your system path. Plus Sublime Text >= 3118.
+
 There are a variety of settings (see [Settings](#settings)) for controlling the syntax highlighting:
 
 | Setting | Default | Description |
 | :------ | :------ | :---------- |
 | `rust_syntax_checking` | `true` | Enable the on-save syntax checking. |
 | `rust_syntax_checking_include_tests` | `true` | Enable checking of test code within `#[cfg(test)]` sections. |
+| `rust_syntax_hide_warnings` | `false` | If true, will not display warning messages. |
 | `rust_syntax_error_color` | `"#F00"` | Color of error messages. |
 | `rust_syntax_warning_color` | `"#FF0"` | Color of warning messages. |
 

--- a/RustEnhanced.sublime-settings
+++ b/RustEnhanced.sublime-settings
@@ -2,6 +2,7 @@
     // Enable the syntax checking plugin, which will highlight any errors during build
     "rust_syntax_checking": true,
     "rust_syntax_checking_include_tests": true,
+    "rust_syntax_hide_warnings": false,
     "rust_syntax_error_color": "#F00",
     "rust_syntax_warning_color":"#FF0"
 

--- a/SyntaxCheckPlugin.py
+++ b/SyntaxCheckPlugin.py
@@ -287,6 +287,13 @@ class rustPluginSyntaxCheckEvent(sublime_plugin.EventListener):
         error_colour = settings.get('rust_syntax_error_color', 'var(--redish)')
         warning_colour = settings.get('rust_syntax_warning_color', 'var(--yellowish)')
 
+        # Include "notes" tied to errors, even if warnings are disabled.
+        if (info['level'] != 'error' and
+            settings.get('rust_syntax_hide_warnings', False) and
+            not parent_info
+           ):
+            return
+
         # TODO: Consider matching the colors used by rustc.
         # - error: red
         #     `bug` appears as "error: internal compiler error"


### PR DESCRIPTION
Update for rust-lang/sublime-rust#142 by @lord to accommodate merge conflicts.