### PR TITLE
Hack-fixed cwd

### DIFF
--- a/SyntaxCheckPlugin.py
+++ b/SyntaxCheckPlugin.py
@@ -61,7 +61,9 @@ class rustPluginSyntaxCheckEvent(sublime_plugin.EventListener):
             # duplicate messages for shared modules.
             self.this_view_found = False
             try:
+                cwd = os.getcwd()
                 self.hide_phantoms(view.window())
+                os.chdir(cwd)
 
                 # Keep track of regions used for highlighting, since Sublime
                 # requires it to be added in one shot.
@@ -94,6 +96,7 @@ class rustPluginSyntaxCheckEvent(sublime_plugin.EventListener):
         # http://stackoverflow.com/questions/3390762/how-do-i-eliminate-windows-consoles-from-spawned-processes-in-python-2-7
         cmd = ' '.join(['cargo']+args)
         print('Running %r' % cmd)
+        cwd = os.getcwd()
         cproc = subprocess.Popen(cmd,
             shell=True, stderr=subprocess.STDOUT, stdout=subprocess.PIPE)
         output = cproc.communicate()
@@ -104,6 +107,7 @@ class rustPluginSyntaxCheckEvent(sublime_plugin.EventListener):
                 continue
             result.append(json.loads(line))
         # print(output)
+        os.chdir(cwd)
         if not result and cproc.returncode:
             print('Failed to run: %s' % cmd)
             print(output)


### PR DESCRIPTION
This fixes my problems with the current working directory.

There are two instances where the cwd is changed while getting the compile messages. 
The first is probably understandable: After running `cargo metadata --no-deps`, cargo seems to have changed the cwd and this change seems to propagate into the plugin. 
The second change is a complete mystery to me: After the call to `view.erase_phantoms('rust-syntax-phantom')` in `hide_phantoms()`, the cwd is lost as well. This seems to be a bug in Sublime itself, if I didn't miss something else plugin-related.

In my particular case, when starting with a file_dir of `~/projects/mio/code/crates/mio_core/src`, after each of those two instances, the cwd would have been "reset" to `~/projects/mio/code`.

Obviously my changes are not a robust solution. I'd propose generally passing the cwd into Popen to avoid such problems in the future.