### PR TITLE
Use shell_cmd instead of cmd in Windows "Run" #157

### DIFF
--- a/RustEnhanced.sublime-build
+++ b/RustEnhanced.sublime-build
@@ -14,7 +14,7 @@
             "name": "Run",
             "windows":
             {
-                "cmd": ["$file_base_name.exe"]
+                "shell_cmd": "\"$file_base_name.exe\""
             }
         }
     ]


### PR DESCRIPTION
As per http://docs.sublimetext.info/en/latest/reference/build_systems/exec.html,
shell_cmd takes precedence over cmd, so overriding cmd when the default version
specifies shell_cmd is pointless.