### PR TITLE
changing attributes from comments to annoations fixes #120

### DIFF
--- a/RustEnhanced.sublime-syntax
+++ b/RustEnhanced.sublime-syntax
@@ -149,6 +149,7 @@ contexts:
       push: macro-block
 
     - include: comments
+    - include: attribute
     - include: strings
     - include: chars
 
@@ -189,14 +190,6 @@ contexts:
       scope: support.type.rust
 
     - include: basic-identifiers
-
-    - match: '#!?\['
-      push:
-        - meta_scope: comment.block.attribute.rust
-        - match: '\]'
-          pop: true
-        - include: strings
-
     - include: numbers
 
     - match: '(?=\{)'
@@ -236,6 +229,15 @@ contexts:
     - match: '\.\.\.|\.\.||[-=<>&|!~@?+*/%^''#$]|\b_\b'
       scope: keyword.operator.rust
 
+  attribute:
+    - match: '#!?\['
+      push:
+        # https://github.com/sublimehq/Packages/issues/709#issuecomment-266835130
+        - meta_scope: meta.annotation.rust 
+        - match: '\]'
+          pop: true
+        - include: strings
+
   block:
     - match: '\}'
       scope: meta.block.rust punctuation.definition.block.end.rust
@@ -249,6 +251,7 @@ contexts:
     - match: '(?=\})'
       pop: true
     - include: statements
+    - include: attribute
 
   group:
     - match: '\)'
@@ -494,6 +497,7 @@ contexts:
         - match: '(?=\})'
           pop: true
         - include: comments
+        - include: attribute
         - match: \bpub\b
           scope: storage.modifier.rust
         - match: '{{identifier}}(?=\s*:)'

--- a/RustEnhanced.sublime-syntax
+++ b/RustEnhanced.sublime-syntax
@@ -235,8 +235,8 @@ contexts:
         # https://github.com/sublimehq/Packages/issues/709#issuecomment-266835130
         - meta_scope: meta.annotation.rust 
         - match: '\]'
+        - include: statements
           pop: true
-        - include: strings
 
   block:
     - match: '\}'

--- a/syntax_test_rust.rs
+++ b/syntax_test_rust.rs
@@ -1,4 +1,4 @@
-// SYNTAX TEST "Packages/Rust Enhanced/RustEnhanced.sublime-syntax"
+// SYNTAX TEST "Packages/sublime-rust/RustEnhanced.sublime-syntax"
 
 // Line comments
 // <- comment.line.double-slash
@@ -197,8 +197,8 @@ struct BasicStruct(i32);
 //                    ^ punctuation.definition.group.end
 
 #[derive(Debug)]
-// <- comment.block.attribute
-//^^^^^^^^^^^^^^ comment.block.attribute
+// <- meta.annotation.rust
+//^^^^^^^^^^^^^^ meta.annotation.rust
 struct PrintableStruct(Box<i32>);
 // ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ meta.struct
 // <- storage.type.struct
@@ -544,6 +544,29 @@ fn my_other_func(e: OperatingSystem) -> u32 {
 //                ^ punctuation.separator
 }
 
+// Test highlighting/scope with struct field attributes
+// https://github.com/rust-lang/sublime-rust/issues/120
+pub struct Claim {
+// ^^^^^^^^^ meta.struct
+    pub claim_id: String,
+//  ^^^ storage.modifier.rust
+    pub patient_id: String,
+    #[serde(skip_serializing_if="Option::is_none")]
+//  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ meta.annotation.rust
+    pub referring: Option<String>,
+    #[serde(skip_serializing_if="Option::is_none")]
+//  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ meta.annotation.rust
+    pub drug: Option<Vec<String>>,
+    #[serde(skip_serializing_if="Option::is_none")]
+//  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ meta.annotation.rust
+    pub ndc: Option<Vec<String>>,
+    #[serde(skip_serializing_if="Option::is_none")]
+//  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ meta.annotation.rust
+    pub rendering: Option<String>,
+    pub date: String,
+
+}
+
 struct Point
 // ^^^^^^^^^ meta.struct
 {
@@ -774,7 +797,7 @@ macro_rules! forward_ref_binop [
 //                                        ^^ meta.path
 
             #[inline]
-//          ^^^^^^^^^ comment.block.attribute
+//          ^^^^^^^^^ meta.annotation.rust
             fn $method(self, other: &'a $u) -> <$t as $imp<$u>>::Output {
 //          ^^ storage.type.function
 //             ^^^^^^^ variable.other

--- a/syntax_test_rust.rs
+++ b/syntax_test_rust.rs
@@ -552,16 +552,18 @@ pub struct Claim {
 //  ^^^ storage.modifier.rust
     pub patient_id: String,
     #[serde(skip_serializing_if="Option::is_none")]
-//  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ meta.annotation.rust
+//                               ^^^^^^^^^^^^^^^ string.quoted.double
+//  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ meta.annotation
     pub referring: Option<String>,
     #[serde(skip_serializing_if="Option::is_none")]
-//  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ meta.annotation.rust
+//    ^^^^^ support.function
+//  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ meta.annotation
     pub drug: Option<Vec<String>>,
     #[serde(skip_serializing_if="Option::is_none")]
-//  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ meta.annotation.rust
+//  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ meta.annotation
     pub ndc: Option<Vec<String>>,
     #[serde(skip_serializing_if="Option::is_none")]
-//  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ meta.annotation.rust
+//  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ meta.annotation
     pub rendering: Option<String>,
     pub date: String,
 


### PR DESCRIPTION
So this is my first attempt at giving attributes in Rust a semantic scope of their own. The decision was to use `meta.annoation.rust` See: https://github.com/sublimehq/Packages/issues/709#issuecomment-266835130

Obviously this will cause attributes to lose their _comment like_ look.
This screenshot shows @dimfeld's bug in a test with the proper scope naming fixed (see https://github.com/rust-lang/sublime-rust/issues/120)
![claimstructtest](https://cloud.githubusercontent.com/assets/936006/23339441/6892e3b8-fc1a-11e6-8000-9b204e7c4e42.png)

As you can see from that screenshot there's still plenty of work to do. But i will pick apart @dten's PR and do it in chunks

This PR should fix both https://github.com/rust-lang/sublime-rust/issues/120 and https://github.com/rust-lang/sublime-rust/issues/51

@wbond & @dten would like to hear your thoughts
@wbond I've added the annoation as a meta scope, is that correct?