### PR TITLE
fixing tuples in closures fixes #164

### DIFF
--- a/RustEnhanced.sublime-syntax
+++ b/RustEnhanced.sublime-syntax
@@ -310,6 +310,8 @@ contexts:
     # scope as soon as we hit something that it not a
     # valid part so the whole rest of the document isn't
     # highlighted using the params scope
+    - match: '(?=\()'
+      push: group
     - match: '(?=[};)\]\n])'
       pop: true
     - match: '\|'
@@ -331,6 +333,8 @@ contexts:
       scope: storage.modifier.rust
     - match: '''{{identifier}}(?!\'')\b'
       scope: storage.modifier.lifetime.rust
+    - match: '(?=\()'
+
 
   closure-return:
     - meta_content_scope: meta.function.closure.rust

--- a/RustEnhanced.sublime-syntax
+++ b/RustEnhanced.sublime-syntax
@@ -334,7 +334,6 @@ contexts:
     - match: '''{{identifier}}(?!\'')\b'
       scope: storage.modifier.lifetime.rust
 
-
   closure-return:
     - meta_content_scope: meta.function.closure.rust
     - include: return-type

--- a/RustEnhanced.sublime-syntax
+++ b/RustEnhanced.sublime-syntax
@@ -333,7 +333,6 @@ contexts:
       scope: storage.modifier.rust
     - match: '''{{identifier}}(?!\'')\b'
       scope: storage.modifier.lifetime.rust
-    - match: '(?=\()'
 
 
   closure-return:

--- a/syntax_test_rust.rs
+++ b/syntax_test_rust.rs
@@ -1,4 +1,4 @@
-// SYNTAX TEST "Packages/Rust Enhanced/RustEnhanced.sublime-syntax"
+// SYNTAX TEST "Packages/sublime-rust/RustEnhanced.sublime-syntax"
 
 // Line comments
 // <- comment.line.double-slash
@@ -271,6 +271,12 @@ let tuple = (1.0, 0i32, "Hello");
 //                 ^^^ storage.type
 //                      ^^^^^^^ string.quoted.double
 //                             ^ punctuation.definition.group.end
+
+// Looks like tuples use meta.group so we'll use that for tuple arguments too
+// fixes https://github.com/rust-lang/sublime-rust/issues/164
+let f = |(x, y)| { x + y };
+//      ^ punctuation.definition.parameters.begin
+//       ^^^^^^ meta.group
 
 let xs: [i32; 5] = [1, 2, 3, 4, 5];
 //    ^ punctuation.separator


### PR DESCRIPTION
Adds the group context to tuples inside of closure arguments.
Tests pass

Not sure if in future we want to be specific about tuples as their own context, but for now this will work.
@dten for review
