### PR TITLE
writeln!(w) breaks formatting

### DIFF
--- a/RustEnhanced.sublime-syntax
+++ b/RustEnhanced.sublime-syntax
@@ -173,7 +173,7 @@ contexts:
         1: support.macro.rust
         2: meta.group.rust punctuation.definition.group.begin.rust
       push:
-        - meta_content_scope: meta.group.rust
+        - meta_scope: meta.group.rust
         - include: comments
         - match: ','
           set:
@@ -182,6 +182,7 @@ contexts:
             - include: format-raw-string
             - match: '(?=\S)'
               set: group-tail
+        - include: group-tail
 
     - match: '\b[[:lower:]_][[:lower:][:digit:]_]*!(?=\s*(\(|\{|\[))'
       scope: support.macro.rust

--- a/syntax_test_rust.rs
+++ b/syntax_test_rust.rs
@@ -259,6 +259,28 @@ impl fmt::Display for PrintableStruct {
 //                ^^^^ string.quoted.double
 //                 ^^ constant.other.placeholder
 //                            ^ punctuation.definition.group.end
+        write!(get_writer(), "{}", "{}")
+// ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ meta.function
+//      ^^^^^^ support.macro
+//            ^^^^^^^^^^^^^^^^^^^^^^^^^^ meta.group
+//             ^^^^^^^^^^ support.function
+//                           ^^^^ string.quoted.double
+//                            ^^ constant.other.placeholder
+//                                 ^^^^ string.quoted.double
+//            ^ punctuation.definition.group.begin
+//                                     ^ punctuation.definition.group.end
+        writeln!(w)
+// ^^^^^^^^^^^^^^^^ meta.function
+//      ^^^^^^^^ support.macro
+//              ^^^ meta.group
+//              ^ punctuation.definition.group.begin
+//                ^ punctuation.definition.group.end
+        println!()
+// ^^^^^^^^^^^^^^^ meta.function
+//      ^^^^^^^^ support.macro
+//              ^^ meta.group
+//              ^ punctuation.definition.group.begin
+//               ^ punctuation.definition.group.end
     }
 // ^^ meta.function meta.block
 //  ^ punctuation.definition.block.end


### PR DESCRIPTION
the special case for `writeln!` expects there to always be a format string, this isn't actually required any more which breaks formatting until the next comma, also all highlighting on the writer itself was broken

fixes the two below lines

```
    writeln!(w)?;
    writeln!(get_writer(), " }}" ,/**/ "yes")?;
```