### PR TITLE
Fix annotation context never getting popped.

### DIFF
--- a/RustEnhanced.sublime-syntax
+++ b/RustEnhanced.sublime-syntax
@@ -233,10 +233,10 @@ contexts:
     - match: '#!?\['
       push:
         # https://github.com/sublimehq/Packages/issues/709#issuecomment-266835130
-        - meta_scope: meta.annotation.rust 
+        - meta_scope: meta.annotation.rust
         - match: '\]'
-        - include: statements
           pop: true
+        - include: statements
 
   block:
     - match: '\}'


### PR DESCRIPTION
The annotation scope was never getting closed since the pop statement was in the wrong place.

BTW, I would like to make some fixes to the syntax definition, particularly revolving around macros.  Would that be OK?  What's the current story with the syntax definition?  There has been some divergence with Sublime's Rust definition.  I also see #116, but it's not clear what's going on.