### PR TITLE
Add fmt-style formatting for additional macros in the standard library.

### DIFF
--- a/RustEnhanced.sublime-syntax
+++ b/RustEnhanced.sublime-syntax
@@ -156,7 +156,7 @@ contexts:
     - match: '\b[[:lower:]_][[:lower:][:digit:]_]*(?=\()'
       scope: support.function.rust
 
-    - match: '\b((?:format|print|println)!)\s*(\()'
+    - match: '\b((?:format|print|println|panic|format_args|unreachable)!)\s*(\()'
       captures:
         1: support.macro.rust
         2: meta.group.rust punctuation.definition.group.begin.rust
@@ -233,7 +233,7 @@ contexts:
     - match: '#!?\['
       push:
         # https://github.com/sublimehq/Packages/issues/709#issuecomment-266835130
-        - meta_scope: meta.annotation.rust 
+        - meta_scope: meta.annotation.rust
         - include: statements
         - match: '\]'
           pop: true

--- a/syntax_test_rust.rs
+++ b/syntax_test_rust.rs
@@ -215,10 +215,10 @@ struct PrintableStruct(Box<i32>);
 // fixes https://github.com/rust-lang/sublime-rust/issues/144
 fn factory() -> Box<Fn(i32) -> i32> {
 // <- storage.type.function
-// ^^^^^^^ entity.name.function 
+// ^^^^^^^ entity.name.function
 //                  ^^^^^^^^^^^^^^ meta.generic
-//                      ^^ storage.type 
-//                              ^^ storage.type   
+//                      ^^ storage.type
+//                              ^^ storage.type
 //                          ^^ punctuation.separator.generic
 
     Box::new(|x| x + 1)
@@ -902,7 +902,7 @@ pub fn next_lex2</* block */T/* comments */:/* everywhere */
     /* help */ PartialOrd // Possibly too many comments
 //  ^^^^^^^^^^ comment.block.rust
 //                        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ comment.line.double-slash.rust
-> (   
+> (
     /* block2 */ data2: &mut [T]  // line
 //  ^^^^^^^^^^^^ source.rust meta.function.rust meta.function.parameters.rust comment.block.rust
 //                                ^^^^^^^ source.rust meta.function.rust meta.function.parameters.rust comment.line.double-slash.rust
@@ -967,3 +967,33 @@ impl<T> Iterator for Fibonacci<T>
 pub const FOO: Option<[i32; 1]> = Some([1]);
 //                    ^ punctuation.definition.group.begin.rust
 //                           ^ punctuation.definition.group.end.rust
+
+pub fn macro_tests() {
+    println!();
+//  ^^^^^^^^ support.macro.rust
+    println!("Example");
+//  ^^^^^^^^ support.macro.rust
+//          ^ punctuation.definition.group.begin
+//           ^^^^^^^^^ string.quoted.double.rust
+//                    ^ punctuation.definition.group.end
+    println!("Example {} {message}", "test", message="hi");
+//                    ^^ constant.other.placeholder.rust
+//                       ^^^^^^^^^ constant.other.placeholder.rust
+    panic!();
+//  ^^^^^^ support.macro.rust
+    panic!("Example");
+//  ^^^^^^ support.macro.rust
+//        ^ punctuation.definition.group.begin
+//         ^^^^^^^^^ string.quoted.double.rust
+//                  ^ punctuation.definition.group.end
+    panic!("Example {} {message}", "test", message="hi");
+//                  ^^ constant.other.placeholder.rust
+//                     ^^^^^^^^^ constant.other.placeholder.rust
+    format_args!("invalid type: {}, expected {}", unexp, exp);
+//  ^^^^^^^^^^^^ support.macro.rust
+//                              ^^ constant.other.placeholder.rust
+//                                           ^^ constant.other.placeholder.rust
+    unreachable!("{:?}", e);
+//  ^^^^^^^^^^^^ support.macro.rust
+//                ^^^^ constant.other.placeholder.rust
+}


### PR DESCRIPTION
Adds panic!, format_args!, and unreachable! to the list of fmt-taking
macros.  Fixes #178