### PR TITLE
Extend comments to include new line

### DIFF
--- a/RustEnhanced.sublime-syntax
+++ b/RustEnhanced.sublime-syntax
@@ -784,12 +784,12 @@ contexts:
     - match: "//[!/]"
       push:
         - meta_scope: comment.line.documentation.rust
-        - match: $
+        - match: $\n?
           pop: true
     - match: //
       push:
         - meta_scope: comment.line.double-slash.rust
-        - match: $
+        - match: $\n?
           pop: true
 
   block-comments:

--- a/syntax_test_rust.rs
+++ b/syntax_test_rust.rs
@@ -2,7 +2,7 @@
 
 // Line comments
 // <- comment.line.double-slash
-// ^^^^^^^^^^^^^ comment.line.double-slash
+// ^^^^^^^^^^^^^^ comment.line.double-slash
 /// Line doc comments
 // <- comment.line.documentation
 // ^^^^^^^^^^^^^ comment.line.documentation


### PR DESCRIPTION
Extending the comment to include the new line character as per sublime's other syntaxes (https://github.com/sublimehq/Packages/blob/master/C%23/C%23.sublime-syntax#L66) fixes https://github.com/rust-lang/sublime-rust/issues/195