### PR TITLE
Fix a bug building with Rust 1.19.

### DIFF
--- a/SyntaxCheckPlugin.py
+++ b/SyntaxCheckPlugin.py
@@ -124,7 +124,7 @@ class RustSyntaxCheckThread(rust_thread.RustThread, rust_proc.ProcListener):
         if method == 'clippy':
             # Clippy does not support cargo target filters, must be run for
             # all targets.
-            cmd = settings.get_command(command_info, self.cwd)
+            cmd = settings.get_command(method, command_info, self.cwd)
             p = rust_proc.RustProc()
             p.run(self.window, cmd['command'], self.cwd, self, env=cmd['env'])
             p.wait()
@@ -134,7 +134,7 @@ class RustSyntaxCheckThread(rust_thread.RustThread, rust_proc.ProcListener):
         td = target_detect.TargetDetector(self.window)
         targets = td.determine_targets(self.triggered_file_name)
         for (target_src, target_args) in targets:
-            cmd = settings.get_command(command_info, self.cwd,
+            cmd = settings.get_command(method, command_info, self.cwd,
                 initial_settings={'target': ' '.join(target_args)})
             if method == 'no-trans':
                 cmd['command'].extend(['--', '-Zno-trans', '-Zunstable-options'])

--- a/docs/build.md
+++ b/docs/build.md
@@ -61,19 +61,21 @@ It also supports Sublime's build settings:
 | `show_errors_inline` | `true` | If true, messages are displayed in line using Sublime's phantoms.  If false, messages are only displayed in the output panel. |
 | `show_panel_on_build` | `true` | If true, an output panel is displayed at the bottom of the window showing the compiler output. |
 
-## Cargo Project Settings
+## Cargo Settings
 
-You can customize how Cargo is run with settings stored in your
-`sublime-project` file.  Settings can be applied per-target (`--lib`,
-`--example foo`, etc.), for specific variants ("Build", "Run", "Test", etc.),
-or globally.
+A variety of settings are available to customize how Cargo is run. These
+settings can be set globally, per-Sublime project, per-Cargo package, for
+specific build variants ("Build", "Run", "Test", etc.), or specific Cargo
+targets (`--lib`, `--example foo`, etc.).
 
 ### Configure Command
 
 To help you configure the Cargo build settings, run the `Rust: Configure Cargo
-Build` command from Sublime's Command Palette (Ctrl-Shift-P / ⌘-Shift-P).
-This will ask you a series of questions for the setting to configure.  The
-first choice is the setting:
+Build` command from Sublime's Command Palette (Ctrl-Shift-P / ⌘-Shift-P). This
+will ask you a series of questions for the setting to configure.  It will
+update your `.sublime-project` or `Users/RustEnhanced.sublime-settings` file
+depending on which options you pick.  The first question is the setting you
+want to update:
 
 Setting | Description
 ------- | -----------
@@ -88,21 +90,30 @@ Default Package/Path | The default package to build, useful if you have a worksp
 
 If you have multiple Cargo packages in your workspace, it will ask for the package to configure.
 
-A setting can be global (for all build invocations), for a specific build variant (such as "Test"), or for a specific build target (such as `--example myprog`).
-
 Caution: If you have not created a `sublime-project` file, then any changes
 you make will be lost if you close the Sublime window.
 
 ### Settings
 
-Settings are stored in your `sublime-project` file under `"cargo_build"` in
-the `"settings"` key. Settings are organized per Cargo package in the
-`"paths"` object.  Paths can either be directories to a Cargo package, or the
-path to a Rust source file (when used with `cargo script`).  The top-level
-keys for each package are:
+Cargo settings are stored in the `"cargo_build"` Sublime setting.  This can be
+either in your `sublime-project` file or in
+`Users/RustEnhanced.sublime-settings`.  `"cargo_build"` is an object with the
+following keys:
 
 Key | Description
 --- | -----------
+`"paths"` | Settings for specific Cargo packages.
+`"default_path"` | The default Cargo package to build (useful for workspaces, see below).
+`"variants"` | Settings per build variant.
+`"defaults"` | Default settings used if not set per target or variant.
+
+Paths should be an absolute path to the directory of a Cargo package, or the
+path to a Rust source file (when used with `cargo script`).
+
+`"paths"` is an object of path keys mapping to an object with the keys:
+
+Path Key | Description
+-------- | -----------
 `"defaults"` | Default settings used if not set per target or variant.
 `"targets"` | Settings per target (such as `"--lib"` or `"--bin foo"`).
 `"variants"` | Settings per build variant.
@@ -119,7 +130,7 @@ An example of a `sublime-project` file:
             "paths": {
                 "/path/to/package": {
                     "defaults": {
-                        "release": true
+                        "release": false
                     },
                     "targets": {
                         "--example ex1": {
@@ -136,7 +147,17 @@ An example of a `sublime-project` file:
                     }
                 }
             },
-            "default_path": "/path/to/package"
+            "default_path": "/path/to/package",
+            "variants": {
+                "run": {
+                    "env": {
+                        "RUST_BACKTRACE": 1
+                    }
+                }
+            },
+            "defaults": {
+                "release": true
+            }
         }
     }
 }
@@ -161,6 +182,19 @@ Setting Name | Description
 The extra args settings support standard Sublime variable expansion (see
 [Build System
 Variables](http://docs.sublimetext.info/en/latest/reference/build_systems/configuration.html#build-system-variables))
+
+### Setting Precedence
+
+The Cargo commands will generally use the most specific setting available.
+The order they are searched are (first found value wins):
+
+1. `.sublime-project` > Cargo Package > Cargo Target
+2. `.sublime-project` > Cargo Package > Build Variant
+3. `.sublime-project` > Cargo Package > Defaults
+4. `.sublime-project` > Build Variant
+5. `RustEnhanced.sublime-settings` > Build Variant
+6. `.sublime-project` > Defaults
+7. `RustEnhanced.sublime-settings` > Defaults
 
 ## Multiple Cargo Projects (Advanced)
 

--- a/rust/cargo_settings.py
+++ b/rust/cargo_settings.py
@@ -143,61 +143,124 @@ class CargoSettings(object):
         if self.project_data is None:
             # Window does not have a Sublime project.
             self.project_data = {}
+        self.re_settings = sublime.load_settings('RustEnhanced.sublime-settings')
 
-    def get(self, key, default=None):
+    def get_global_default(self, key, default=None):
+        return self.re_settings.get('cargo_build', {})\
+                               .get('defaults', {})\
+                               .get(key, default)
+
+    def set_global_default(self, key, value):
+        cb = self.re_settings.get('cargo_build', {})
+        cb.setdefault('defaults', {})[key] = value
+        self.re_settings.set('cargo_build', cb)
+        sublime.save_settings('RustEnhanced.sublime-settings')
+
+    def get_project_default(self, key, default=None):
+        return self.project_data.get('settings', {})\
+                                .get('cargo_build', {})\
+                                .get('defaults', {})\
+                                .get(key, default)
+
+    def set_project_default(self, key, value):
+        self.project_data.setdefault('settings', {})\
+                         .setdefault('cargo_build', {})\
+                         .setdefault('defaults', {})[key] = value
+        self._set_project_data()
+
+    def get_global_variant(self, variant, key, default=None):
+        return self.re_settings.get('cargo_build', {})\
+                               .get('variants', {})\
+                               .get(variant, {})\
+                               .get(key, default)
+
+    def set_global_variant(self, variant, key, value):
+        cb = self.re_settings.get('cargo_build', {})
+        cb.setdefault('variants', {})\
+          .setdefault(variant, {})[key] = value
+        self.re_settings.set('cargo_build', cb)
+        sublime.save_settings('RustEnhanced.sublime-settings')
+
+    def get_project_variant(self, variant, key, default=None):
+        return self.project_data.get('settings', {})\
+                                .get('cargo_build', {})\
+                                .get('variants', {})\
+                                .get(variant, {})\
+                                .get(key, default)
+
+    def set_project_variant(self, variant, key, value):
+        self.project_data.setdefault('settings', {})\
+                         .setdefault('cargo_build', {})\
+                         .setdefault('variants', {})\
+                         .setdefault(variant, {})[key] = value
+        self._set_project_data()
+
+    def get_project_package_default(self, path, key, default=None):
+        path = os.path.normpath(path)
+        return self.project_data.get('settings', {})\
+                                .get('cargo_build', {})\
+                                .get('paths', {})\
+                                .get(path, {})\
+                                .get('defaults', {})\
+                                .get(key, default)
+
+    def set_project_package_default(self, path, key, value):
+        path = os.path.normpath(path)
+        self.project_data.setdefault('settings', {})\
+                         .setdefault('cargo_build', {})\
+                         .setdefault('paths', {})\
+                         .setdefault(path, {})\
+                         .setdefault('defaults', {})[key] = value
+        self._set_project_data()
+
+    def get_project_package_variant(self, path, variant, key, default=None):
+        path = os.path.normpath(path)
+        return self.project_data.get('settings', {})\
+                                .get('cargo_build', {})\
+                                .get('paths', {})\
+                                .get(path, {})\
+                                .get('variants', {})\
+                                .get(variant, {})\
+                                .get(key, default)
+
+    def set_project_package_variant(self, path, variant, key, value):
+        path = os.path.normpath(path)
+        self.project_data.setdefault('settings', {})\
+                         .setdefault('cargo_build', {})\
+                         .setdefault('paths', {})\
+                         .setdefault(path, {})\
+                         .setdefault('variants', {})\
+                         .setdefault(variant, {})[key] = value
+        self._set_project_data()
+
+    def get_project_package_target(self, path, target, key, default=None):
+        path = os.path.normpath(path)
+        return self.project_data.get('settings', {})\
+                                .get('cargo_build', {})\
+                                .get('paths', {})\
+                                .get(path, {})\
+                                .get('targets', {})\
+                                .get(target, {})\
+                                .get(key, default)
+
+    def set_project_package_target(self, path, target, key, value):
+        path = os.path.normpath(path)
+        self.project_data.setdefault('settings', {})\
+                         .setdefault('cargo_build', {})\
+                         .setdefault('paths', {})\
+                         .setdefault(path, {})\
+                         .setdefault('targets', {})\
+                         .setdefault(target, {})[key] = value
+        self._set_project_data()
+
+    def get_project_base(self, key, default=None):
         return self.project_data.get('settings', {})\
                                 .get('cargo_build', {})\
                                 .get(key, default)
 
-    def set(self, key, value):
+    def set_project_base(self, key, value):
         self.project_data.setdefault('settings', {})\
                          .setdefault('cargo_build', {})[key] = value
-        self._set_project_data()
-
-    def get_with_target(self, path, target, key, default=None):
-        path = os.path.normpath(path)
-        pdata = self.project_data.get('settings', {})\
-                                 .get('cargo_build', {})\
-                                 .get('paths', {})\
-                                 .get(path, {})
-        if target:
-            d = pdata.get('targets', {}).get(target, {})
-        else:
-            d = pdata.get('defaults', {})
-        return d.get(key, default)
-
-    def get_with_variant(self, path, variant, key, default=None):
-        path = os.path.normpath(path)
-        vdata = self.project_data.get('settings', {})\
-                                 .get('cargo_build', {})\
-                                 .get('paths', {})\
-                                 .get(path, {})\
-                                 .get('variants', {})\
-                                 .get(variant, {})
-        return vdata.get(key, default)
-
-    def set_with_target(self, path, target, key, value):
-        path = os.path.normpath(path)
-        pdata = self.project_data.setdefault('settings', {})\
-                                 .setdefault('cargo_build', {})\
-                                 .setdefault('paths', {})\
-                                 .setdefault(path, {})
-        if target:
-            d = pdata.setdefault('targets', {}).setdefault(target, {})
-        else:
-            d = pdata.setdefault('defaults', {})
-        d[key] = value
-        self._set_project_data()
-
-    def set_with_variant(self, path, variant, key, value):
-        path = os.path.normpath(path)
-        vdata = self.project_data.setdefault('settings', {})\
-                                 .setdefault('cargo_build', {})\
-                                 .setdefault('paths', {})\
-                                 .setdefault(path, {})\
-                                 .setdefault('variants', {})\
-                                 .setdefault(variant, {})
-        vdata[key] = value
         self._set_project_data()
 
     def _set_project_data(self):
@@ -209,31 +272,17 @@ class CargoSettings(object):
                 Any changes to the Cargo build settings will be lost if you close the window."""))
         self.window.set_project_data(self.project_data)
 
-    def get_command(self, cmd_info, settings_path, initial_settings={}):
-        """Generates the command arguments for running Cargo.
+    def determine_target(self, cmd_name, settings_path,
+                         cmd_info=None, override=None):
+        if cmd_info is None:
+            cmd_info = CARGO_COMMANDS[cmd_name]
 
-        :Returns: A dictionary with the keys:
-            - `command`: The command to run as a list of strings.
-            - `env`: Dictionary of environment variables (or None).
-
-            Returns None if the command cannot be constructed.
-        """
-        command = cmd_info['command']
-        result = ['cargo']
-        pdata = self.project_data.get('settings', {})\
-                                 .get('cargo_build', {})\
-                                 .get('paths', {})\
-                                 .get(settings_path, {})
-        vdata = pdata.get('variants', {})\
-                     .get(command, {})
-
-        def vdata_get(key, default=None):
-            return initial_settings.get(key, vdata.get(key, default))
-
-        # Target
         target = None
         if cmd_info.get('allows_target', False):
-            tcfg = vdata_get('target')
+            if override:
+                tcfg = override
+            else:
+                tcfg = self.get_project_package_variant(settings_path, cmd_name, 'target')
             if tcfg == 'auto':
                 # If this fails, leave target as None and let Cargo sort it
                 # out (it may display an error).
@@ -246,14 +295,89 @@ class CargoSettings(object):
                         target = ' '.join(cmd_line)
             else:
                 target = tcfg
+        return target
 
-        def get(key, default=None):
-            d = pdata.get('defaults', {}).get(key, default)
-            v_val = vdata.get(key, d)
-            t_val = pdata.get('targets', {}).get(target, {}).get(key, v_val)
-            return initial_settings.get(key, t_val)
+    def get_computed(self, settings_path, variant, target, key,
+                     default=None, initial_settings={}):
+        """Get the configuration value for the given key."""
+        v = initial_settings.get(key)
+        if v is None:
+            v = self.get_project_package_target(settings_path, target, key)
+            if v is None:
+                v = self.get_project_package_variant(settings_path, variant, key)
+                if v is None:
+                    v = self.get_project_package_default(settings_path, key)
+                    if v is None:
+                        v = self.get_project_variant(variant, key)
+                        if v is None:
+                            v = self.get_global_variant(variant, key)
+                            if v is None:
+                                v = self.get_project_default(key)
+                                if v is None:
+                                    v = self.get_global_default(key, default)
+        return v
 
-        toolchain = get('toolchain', None)
+    def get_merged(self, settings_path, variant, target, key,
+                   initial_settings={}):
+        """Get the configuration value for the given key.
+
+        This assumes the value is a dictionary, and will merge all values from
+        each level.  This is primarily used for the `env` environment
+        variables.
+        """
+        result = self.get_global_default(key, {}).copy()
+
+        proj_def = self.get_project_default(key, {})
+        result.update(proj_def)
+
+        glbl_var = self.get_global_variant(variant, key, {})
+        result.update(glbl_var)
+
+        proj_var = self.get_project_variant(variant, key, {})
+        result.update(proj_var)
+
+        pp_def = self.get_project_package_default(settings_path, key, {})
+        result.update(pp_def)
+
+        pp_var = self.get_project_package_variant(settings_path, variant, key, {})
+        result.update(pp_var)
+
+        pp_tar = self.get_project_package_target(settings_path, target, key, {})
+        result.update(pp_tar)
+
+        initial = initial_settings.get(key, {})
+        result.update(initial)
+        return result
+
+    def get_command(self, cmd_name, cmd_info,
+                    settings_path, initial_settings={}):
+        """Generates the command arguments for running Cargo.
+
+        :param cmd_name: The name of the command, the key used to select a
+            "variant".
+        :param cmd_info: Dictionary from `CARGO_COMMANDS` with rules on how to
+            construct the command.
+        :param settings_path: The absolute path to the Cargo project root
+            directory.
+        :keyword initial_settings: Initial settings to inject which override
+            all other settings.
+
+        :Returns: A dictionary with the keys:
+            - `command`: The command to run as a list of strings.
+            - `env`: Dictionary of environment variables (or None).
+
+            Returns None if the command cannot be constructed.
+        """
+        target = self.determine_target(cmd_name, settings_path,
+            cmd_info=cmd_info, override=initial_settings.get('target'))
+
+        def get_computed(key, default=None):
+            return self.get_computed(settings_path, cmd_name, target, key,
+                default=default, initial_settings=initial_settings)
+
+        result = ['cargo']
+
+        toolchain = get_computed('toolchain', None)
         if toolchain:
             result.append('+' + toolchain)
 
@@ -266,13 +390,13 @@ class CargoSettings(object):
 
         # target_triple
         if cmd_info.get('allows_target_triple', False):
-            v = get('target_triple', None)
+            v = get_computed('target_triple', None)
             if v:
                 result.extend(['--target', v])
 
         # release (profile)
         if cmd_info.get('allows_release', False):
-            v = get('release', False)
+            v = get_computed('release', False)
             if v:
                 result.append('--release')
 
@@ -282,10 +406,10 @@ class CargoSettings(object):
 
         # features
         if cmd_info.get('allows_features', False):
-            v = get('no_default_features', False)
+            v = get_computed('no_default_features', False)
             if v:
                 result.append('--no-default-features')
-            v = get('features', None)
+            v = get_computed('features', None)
             if v:
                 if v.upper() == 'ALL':
                     result.append('--all-features')
@@ -295,11 +419,11 @@ class CargoSettings(object):
 
         # Add path from current active view (mainly for "cargo script").
         if cmd_info.get('requires_view_path', False):
-            script_path = get('script_path')
+            script_path = get_computed('script_path')
             if not script_path:
                 if not util.active_view_is_rust():
                     sublime.error_message(util.multiline_fix("""
-                        Cargo build command %r requires the current view to be a Rust source file.""" % command))
+                        Cargo build command %r requires the current view to be a Rust source file.""" % cmd_info['name']))
                     return None
                 script_path = self.window.active_view().file_name()
             result.append(script_path)
@@ -309,22 +433,20 @@ class CargoSettings(object):
                 self.window.extract_variables())
 
         # Extra args.
-        extra_cargo_args = get('extra_cargo_args')
+        extra_cargo_args = get_computed('extra_cargo_args')
         if extra_cargo_args:
             extra_cargo_args = expand(extra_cargo_args)
             result.extend(shlex.split(extra_cargo_args))
 
-        extra_run_args = get('extra_run_args')
+        extra_run_args = get_computed('extra_run_args')
         if extra_run_args:
             extra_run_args = expand(extra_run_args)
             result.append('--')
             result.extend(shlex.split(extra_run_args))
 
         # Compute the environment.
-        env = pdata.get('defaults', {}).get('env', {})
-        env.update(vdata.get('env', {}))
-        env.update(pdata.get('targets', {}).get(target, {}).get('env', {}))
-        env.update(initial_settings.get('env', {}))
+        env = self.get_merged(settings_path, cmd_name, target, 'env',
+            initial_settings=initial_settings)
         for k, v in env.items():
             env[k] = os.path.expandvars(v)
         if not env:

--- a/rust/util.py
+++ b/rust/util.py
@@ -56,13 +56,17 @@ def debug(msg, *args):
     print(msg % args)
 
 
-def get_rustc_version(window, cwd):
+def get_rustc_version(window, cwd, toolchain=None):
     """Returns the rust version for the given directory.
 
     :Returns: A string such as '1.16.0' or '1.17.0-nightly'.
     """
     from . import rust_proc
-    output = rust_proc.check_output(window, ['rustc', '--version'], cwd)
+    cmd = ['rustc']
+    if toolchain:
+        cmd.append('+' + toolchain)
+    cmd.append('--version')
+    output = rust_proc.check_output(window, cmd, cwd)
     # Example outputs:
     # rustc 1.15.1 (021bd294c 2017-02-08)
     # rustc 1.16.0-beta.2 (bc15d5281 2017-02-16)

--- a/tests/error-tests/benches/bench_err.rs
+++ b/tests/error-tests/benches/bench_err.rs
@@ -3,4 +3,5 @@
 
    #[asdf]
 // ^^^^^^^ERR The attribute `asdf` is currently unknown
+// ^^^^^^^HELP(>=1.21.0-nightly) add #![feature(custom_attribute)]
 fn f() {}

--- a/tests/error-tests/tests/binop-mul-bool.rs
+++ b/tests/error-tests/tests/binop-mul-bool.rs
@@ -11,5 +11,7 @@
 // error-pattern:`*` cannot be applied to type `bool`
 
 fn main() { let x = true * false; }
-//                  ^^^^ERR binary operation
-//                  ^^^^NOTE an implementation of
+//                  ^^^^ERR(<1.19.0) binary operation
+//                  ^^^^NOTE(<1.19.0) an implementation of
+//                  ^^^^^^^^^^^^ERR(>=1.19.0) binary operation
+//                  ^^^^^^^^^^^^NOTE(>=1.19.0) an implementation of

--- a/tests/error-tests/tests/cast-to-unsized-trait-object-suggestion.rs
+++ b/tests/error-tests/tests/cast-to-unsized-trait-object-suggestion.rs
@@ -15,6 +15,6 @@ fn main() {
 //        ^^^^HELP &1 as &Send
     Box::new(1) as Send;
 //  ^^^^^^^^^^^^^^^^^^^ERR cast to unsized type
-//                 ^^^^HELP try casting to a `Box` instead:
+//                 ^^^^HELP try casting to a `Box` instead
 //                 ^^^^HELP Box::new(1) as Box<Send>;
 }

--- a/tests/test_cargo_settings.py
+++ b/tests/test_cargo_settings.py
@@ -1,0 +1,56 @@
+"""Tests for configuration settings and Cargo build."""
+
+import os
+
+from rust_test_common import *
+
+
+class TestCargoSettings(TestBase):
+
+    def test_settings(self):
+        window = sublime.active_window()
+        cmd_info = cargo_settings.CARGO_COMMANDS['build']
+        manifest_dir = os.path.join(plugin_path, 'tests', 'multi-targets')
+        settings = cargo_settings.CargoSettings(window)
+        settings.load()
+
+        def check_cmd(expected_cmd):
+            cmd = settings.get_command('build',
+                cmd_info, manifest_dir)['command']
+            self.assertEqual(cmd, expected_cmd.split())
+
+        cmd = 'cargo build --message-format=json'
+        check_cmd(cmd)
+
+        cb = {'defaults': {'extra_cargo_args': 'global_args'}}
+        self._override_setting('cargo_build', cb)
+        check_cmd(cmd + ' global_args')
+
+        settings.set_project_default('extra_cargo_args', 'project_defaults')
+        check_cmd(cmd + ' project_defaults')
+
+        cb['variants'] = {'build': {'extra_cargo_args': 'global_var_args'}}
+        self._override_setting('cargo_build', cb)
+        check_cmd(cmd + ' global_var_args')
+
+        settings.set_project_variant('build',
+            'extra_cargo_args', 'project_var_args')
+        check_cmd(cmd + ' project_var_args')
+
+        settings.set_project_package_default(manifest_dir,
+            'extra_cargo_args', 'proj_pack_def_arg')
+        check_cmd(cmd + ' proj_pack_def_arg')
+
+        settings.set_project_package_variant(manifest_dir, 'build',
+            'extra_cargo_args', 'proj_pack_var_arg')
+        check_cmd(cmd + ' proj_pack_var_arg')
+
+        settings.set_project_package_target(manifest_dir, '--example ex1',
+            'extra_cargo_args', 'proj_pack_target_args')
+        # Does not change.
+        check_cmd(cmd + ' proj_pack_var_arg')
+
+        # Change the default target.
+        settings.set_project_package_variant(manifest_dir, 'build', 'target',
+            '--example ex1')
+        check_cmd('cargo build --example ex1 --message-format=json proj_pack_target_args')

--- a/tests/workspace/workspace1/src/lib.rs
+++ b/tests/workspace/workspace1/src/lib.rs
@@ -5,6 +5,7 @@ mod anothermod;
 //       ^^^^^^^^ERR(>=1.18.0) recursive type `S` has infinite size
 //       ^^^^^^^^HELP(>=1.18.0) insert indirection
     recursive: S
+//  ^^^^^^^^^^^^ERR(>=1.19.0) recursive without indirection
 }/*END*/
 // ~ERR(<1.18.0) recursive type has infinite size
 // ~ERR(<1.18.0) recursive type `S` has infinite size


### PR DESCRIPTION
Due to a bug (rust-lang/cargo#4223), Rust was displaying the stdout of the compiler, causing the parsing code to get confused.  Also, update tests for 1.19 message changes, and deprecation of no-trans.

NOTE: This depends on the changes from #197 (the settings need overriding).  I'm not sure how Github will handle that.  I can separate this if necessary (the critical change is in rust_proc.py).


