### PR TITLE
Use Sublime 3's new edit_settings command to edit Rust Enhanced settings.

### DIFF
--- a/Main.sublime-menu
+++ b/Main.sublime-menu
@@ -15,14 +15,13 @@
                         "children":
                         [
                             {
-                                "command": "open_file",
-                                "args": {"file": "${packages}/Rust Enhanced/RustEnhanced.sublime-settings"},
-                                "caption": "Settings – Default"
-                            },
-                            {
-                                "command": "open_file",
-                                "args": {"file": "${packages}/User/RustEnhanced.sublime-settings"},
-                                "caption": "Settings – User"
+                                "caption": "Settings",
+                                "command": "edit_settings",
+                                "args":
+                                {
+                                    "base_file": "${packages}/Rust Enhanced/RustEnhanced.sublime-settings",
+                                    "default": "{\n\t$0\n}\n"
+                                }
                             }
                         ]
                     }

--- a/RustEnhanced.sublime-commands
+++ b/RustEnhanced.sublime-commands
@@ -23,4 +23,13 @@
         "caption": "Rust: Configure Cargo Build",
         "command": "cargo_configure"
     },
+    {
+        "caption": "Preferences: Rust Enhanced Settings",
+        "command": "edit_settings",
+        "args":
+        {
+            "base_file": "${packages}/Rust Enhanced/RustEnhanced.sublime-settings",
+            "default": "{\n\t$0\n}\n"
+        }
+    }
 ]


### PR DESCRIPTION
This command will open a new window with the defaults on one side and the user's file on the other.
