### PR TITLE
impl trait / yield syntax

### DIFF
--- a/RustEnhanced.sublime-syntax
+++ b/RustEnhanced.sublime-syntax
@@ -417,7 +417,7 @@ contexts:
     - match: '{{identifier}}'
     - match: ':|,'
       scope: punctuation.separator.rust
-    - match: '\+|\bas\b'
+    - match: '\+|\bas\b|='
       scope: keyword.operator.rust
     - match: '\S'
       scope: invalid.illegal.rust

--- a/RustEnhanced.sublime-syntax
+++ b/RustEnhanced.sublime-syntax
@@ -124,7 +124,7 @@ contexts:
     - match: \b(crate|extern|use|where)\b
       scope: keyword.other.rust
 
-    - match: \b(break|else|for|if|loop|match|while|continue)\b
+    - match: \b(break|else|for|if|loop|match|while|continue|yield)\b
       scope: keyword.control.rust
 
     - match: \breturn\b
@@ -298,6 +298,13 @@ contexts:
       scope: support.type.rust 
 
   return-type:
+    - match: '\bimpl\b'
+      scope: storage.type.impl.rust
+      push:
+        - include: comments
+        - include: impl-generic
+        - match: '(?=\S)'
+          pop: true
     - match: '->'
       scope: punctuation.separator.rust
       push:

--- a/syntax_test_rust.rs
+++ b/syntax_test_rust.rs
@@ -1,4 +1,4 @@
-// SYNTAX TEST "Packages/sublime-rust/RustEnhanced.sublime-syntax"
+// SYNTAX TEST "Packages/Rust Enhanced/RustEnhanced.sublime-syntax"
 
 // Line comments
 // <- comment.line.double-slash

--- a/syntax_test_rust.rs
+++ b/syntax_test_rust.rs
@@ -1051,3 +1051,9 @@ impl<T> From<AsRef<T>> for CliError<T> { }
 //^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ meta.impl
 //                         ^^^^^^^^ entity.name.impl
 //                                 ^^^ meta.generic
+
+fn legal_dates_iter() -> Box<Iterator<Item = Date<UTC>>> {
+//                       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ meta.function.return-type meta.generic
+//                                         ^ keyword.operator
+    unimplemented!()
+}

--- a/syntax_test_rust.rs
+++ b/syntax_test_rust.rs
@@ -1057,3 +1057,12 @@ fn legal_dates_iter() -> Box<Iterator<Item = Date<UTC>>> {
 //                                         ^ keyword.operator
     unimplemented!()
 }
+
+fn numbers() -> impl Iterator<Item = u64> {
+//              ^^^^^^^^^^^^^^^^^^^^^^^^^ meta.function.return-type
+//              ^^^^ meta.function.return-type storage.type.impl
+//                   ^^^^^^^^ meta.function.return-type support.type
+//                           ^^^^^^^^^^^^ meta.function.return-type meta.generic
+    Generator(move || for a in (0..10) { yield a; } })
+//                                       ^^^^^ keyword.control
+}


### PR DESCRIPTION
below syntax now highlights properly


```
fn numbers() -> impl Iterator<Item = u64> {
    Generator(move || for a in (0..10) { yield a; } })
}
```